### PR TITLE
A few Fixes to the redis backend and the hash function, probably worth to merge, probably not.

### DIFF
--- a/docs/source/tasks.rst
+++ b/docs/source/tasks.rst
@@ -35,3 +35,28 @@ between the throughput and latency. You might quibble with the default, but the
 principle is sound and it is only a default: the setting is there to give you
 more control.
 
+Identifying tasks
+-----------------
+
+In the module ``jug.hash``, jug attempts to construct a unique identifier, called 
+a hash, for each of your tasks. For doing that, the name of the function involved
+invoked in the task together with  the parameters that it receives are used. This
+makes jug easy to use but has some drawbacks: 
+
+- If your functions take long/big arguments, the hash process will potentially be 
+  costly. That's a common situation when you are processing arrays for example, or 
+  if you are using sets/dictionaries, in which case the default handling needs to get a sorted 
+  list from the elements of the set/dictionary.
+
+- Jug might now know how to handle the types of your arguments,
+
+- Arguments might be equivalent, and thus the tasks should be identified in the 
+  same way, without jug knowing. As a very contrived example, suppose that a task uses 
+  an argument which is an angle and for the purpose of your program all the values 
+  are equivalent modulo 2*pi.
+
+The solution for this is to provide a ``__jug_hash__`` keyword argument to the Task 
+constructor specifying an object that should be used to build the hash instead of 
+the function arguments. Or, alternatively, to provide a ``__jug_hash__`` method to
+the problematic arguments: this method should return a string to feed the hash function. 
+

--- a/jug/backends/redis_store.py
+++ b/jug/backends/redis_store.py
@@ -48,7 +48,7 @@ def _lockname(name):
 
 _LOCKED = 1
 
-_redis_urlpat = re.compile('redis://(?P<host>[A-Za-z0-9\.]+)(?P<port>\:[0-9]+)?/')
+_redis_urlpat = re.compile(r'redis://(?P<host>[A-Za-z0-9\.]+)(\:(?P<port>[0-9]+))?/')
 
 
 class redis_store(base_store):
@@ -61,6 +61,10 @@ class redis_store(base_store):
         match = _redis_urlpat.match(url)
         if match:
             redis_params = match.groupdict()
+            if redis_params['port'] == None:
+                del redis_params['port']
+            else:
+                redis_params['port'] = int( redis_params['port'] )
         logging.info('connecting to %s' % redis_params)
 
         self.redis = redis.Redis(**redis_params)

--- a/jug/task.py
+++ b/jug/task.py
@@ -63,6 +63,12 @@ tricky to support since the general code relies on the function name)''')
         self.name = '%s.%s' % (f.__module__, f.__name__)
         self.f = f
         self.args = args
+        __jug_hash__ = kwargs.pop( '__jug_hash__', None )
+        
+        # Sometimes the best way of identifying a task might come from 
+        # the client himself.
+        if __jug_hash__ != None:
+            self.jug_hash_precursor =  __jug_hash__ 
         self.kwargs = kwargs
         alltasks.append(self)
 
@@ -226,8 +232,12 @@ tricky to support since the general code relies on the function name)''')
     def __jug_hash__(self):
         M = new_hash_object()
         M.update(self.name)
-        hash_update(M, enumerate(self.args))
-        hash_update(M, self.kwargs.iteritems())
+        if hasattr( self, 'jug_hash_tuple'):
+            hash_update( M, self.jug_hash_precursor )
+        else: 
+            # Take the default, but somehow hazardous path...
+            hash_update(M, enumerate(self.args))
+            hash_update(M, self.kwargs.iteritems())
         value = M.hexdigest()
         self.__jug_hash__ = lambda : value
         return value


### PR DESCRIPTION
-   The url decomposition regexp for the redis back-end apparently had a problem.
- The hash-from-arguments approach didn't work for my particular
  problem: a type can be 'pickle-able' without the pickle being
  unique, something that makes tasks non-uniquely identifiable. So, made it 
  possible for the user to control the hash somehow. 
