### PR TITLE
Use IPython debugger as execution exception interactive debugger if available.

### DIFF
--- a/jug/jug.py
+++ b/jug/jug.py
@@ -166,9 +166,31 @@ def execution_loop(tasks, options, tasks_executed, tasks_loaded):
                     logging.info('Already in execution %s...' % t.name)
             except Exception as e:
                 if options.pdb:
-                    import pdb, sys
+                    import sys
                     _,_, tb = sys.exc_info()
-                    pdb.post_mortem(tb)
+
+                    try:
+                        import IPython
+                        try:
+                            #Attempt to load IPython debugger
+                            import IPython.core.ipapi
+                            import IPython.core.debugger
+                            ip = IPython.core.ipapi.get()
+                            debugger = IPython.core.debugger.Pdb(ip.colors)
+                        except ImportError:
+                            #Fallback to older version of IPython API
+                            import IPython.ipapi
+                            import IPython.Debugger
+                            shell = IPython.Shell.IPShell(argv=[''])
+                            ip = IPython.ipapi.get()
+                            debugger=IPythong.Debugger.Pdb(ip.options.colors)
+                    except ImportError:
+                        #Fallback to standard debugger
+                        import pdb
+                        debugger = pdb.Pdb()
+
+                    debugger.reset()
+                    debugger.interaction(None, tb)
                 else:
                     import itertools
                     logging.critical('Exception while running %s: %s' % (t.name,e))

--- a/jug/options.py
+++ b/jug/options.py
@@ -123,7 +123,7 @@ execute OPTIONS
     information, but is necessary if keeping too much in memory is leading to
     memory errors.
 --pdb
-    Call python debugger on errors
+    Call interactive debugger on errors. Preferentially uses IPython debugger.
 --keep-going
     Keep going after errors
 


### PR DESCRIPTION
Load and use IPython debugger for interactive debugging if available
during task exception handling. Fallback to pre v.11 IPython api if
needed. Fallback to standard debugger if IPython is not installed.

I considered making this a configurable option, however I couldn't think of a use case in which one would significantly prefer pdb over ipdb. Given that the shell functionality requires IPython, I assume nearly any user who uses interactive debugging would prefer the consistant use of the IPython shell.
