### PR TITLE
Fix redis url regexp to match hostname with dashes

### DIFF
--- a/jug/backends/redis_store.py
+++ b/jug/backends/redis_store.py
@@ -48,7 +48,7 @@ def _lockname(name):
 
 _LOCKED = 1
 
-_redis_urlpat = re.compile(r'redis://(?P<host>[A-Za-z0-9\.]+)(\:(?P<port>[0-9]+))?/')
+_redis_urlpat = re.compile(r'redis://(?P<host>[A-Za-z0-9\.\-]+)(\:(?P<port>[0-9]+))?/')
 
 
 class redis_store(base_store):


### PR DESCRIPTION
The regexp in redis_store.py had a missing dash, hence hostnames that included dashes weren't accepted as valid redis urls.
