### PR TITLE
Run tests on installed package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,7 @@ install:
   - pip install redis
   - pip install pyyaml
   - pip install .
-script: nosetests
+script:
+  - mkdir _test
+  - cd _test
+  - nosetests jug

--- a/jug/tests/test_barrier.py
+++ b/jug/tests/test_barrier.py
@@ -1,15 +1,24 @@
+import inspect
+import os
+
 import jug.jug
 from jug.tests.task_reset import task_reset
 from jug.tests.utils import simple_execute
 from jug.options import default_options
 from functools import reduce
 
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
+
+
 @task_reset
 def test_barrier():
-    store, space = jug.jug.init('jug/tests/jugfiles/wbarrier.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'wbarrier.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     assert 'four' not in space
     simple_execute()
-    store, space = jug.jug.init('jug/tests/jugfiles/wbarrier.py', store)
+    store, space = jug.jug.init(jugfile, store)
     assert 'four' in space
 
     # This is a regression test:
@@ -22,10 +31,11 @@ def product(vals):
 
 @task_reset
 def test_mapreduce_barrier():
-    store, space = jug.jug.init('jug/tests/jugfiles/barrier_mapreduce.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'barrier_mapreduce.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     assert 'values' not in space
     simple_execute()
-    store, space = jug.jug.init('jug/tests/jugfiles/barrier_mapreduce.py', store)
+    store, space = jug.jug.init(jugfile, store)
     assert 'values' in space
     assert space['values'] == product(list(range(20)))
     simple_execute()
@@ -35,16 +45,17 @@ def test_barrier_once():
     import sys
     options = default_options.copy()
     options.jugdir = 'dict_store'
-    options.jugfile = 'jug/tests/jugfiles/wbarrier.py'
+    options.jugfile = os.path.join(_jugdir, 'wbarrier.py')
     jug.jug.execute(options)
     assert 'four' in dir(sys.modules['wbarrier'])
 
 @task_reset
 def test_bvalue():
-    store, space = jug.jug.init('jug/tests/jugfiles/bvalue.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'bvalue.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     assert 'four' not in space
     simple_execute()
-    store, space = jug.jug.init('jug/tests/jugfiles/bvalue.py', store)
+    store, space = jug.jug.init(jugfile, store)
     assert 'four' in space
     assert space['four'] == 4
 

--- a/jug/tests/test_compound.py
+++ b/jug/tests/test_compound.py
@@ -1,3 +1,6 @@
+import inspect
+import os
+
 import jug.compound
 import jug.mapreduce
 import numpy as np
@@ -6,6 +9,11 @@ from jug.tests.utils import simple_execute
 from jug.compound import CompoundTask
 from jug.tests.test_mapreduce import mapper, reducer, dfs_run
 from jug.tests.task_reset import task_reset
+
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
+
 
 @task_reset
 def test_compound():
@@ -21,9 +29,10 @@ def test_compound():
 
 @task_reset
 def test_w_barrier():
-    store, space = jug.jug.init('jug/tests/jugfiles/compound_wbarrier.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'compound_wbarrier.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
-    store, space = jug.jug.init('jug/tests/jugfiles/compound_wbarrier.py', store)
+    store, space = jug.jug.init(jugfile, store)
     simple_execute()
     assert 'sixteen' in space
     assert space['sixteen'].result == 16
@@ -31,22 +40,24 @@ def test_w_barrier():
 
 @task_reset
 def test_non_simple():
-    store, space = jug.jug.init('jug/tests/jugfiles/compound_nonsimple.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'compound_nonsimple.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
-    store, space = jug.jug.init('jug/tests/jugfiles/compound_nonsimple.py', store)
+    store, space = jug.jug.init(jugfile, store)
     simple_execute()
-    store, space = jug.jug.init('jug/tests/jugfiles/compound_nonsimple.py', store)
+    store, space = jug.jug.init(jugfile, store)
     simple_execute()
     assert 'sixteen' in space
     assert space['sixteen'].result == 16
 
 @task_reset
 def test_compound_jugfile():
-    store, space = jug.jug.init('jug/tests/jugfiles/compound.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'compound.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
     assert 'sixteen' in space
     assert space['sixteen'].result == 16
-    store, space = jug.jug.init('jug/tests/jugfiles/compound.py', store)
+    store, space = jug.jug.init(jugfile, store)
     assert 'sixteen' in space
     assert space['sixteen'].result == 16
 
@@ -57,12 +68,13 @@ def test_debug():
     from jug.options import default_options
     options = default_options.copy()
     options.debug = True
+    jugfile = os.path.join(_jugdir, 'compound.py')
 
-    store, space = jug.jug.init('jug/tests/jugfiles/compound.py', 'dict_store')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     execution_loop(alltasks, options)
     assert 'sixteen' in space
     assert space['sixteen'].result == 16
-    store, space = jug.jug.init('jug/tests/jugfiles/compound.py', store)
+    store, space = jug.jug.init(jugfile, store)
     assert 'sixteen' in space
     assert space['sixteen'].result == 16
 

--- a/jug/tests/test_io.py
+++ b/jug/tests/test_io.py
@@ -1,9 +1,17 @@
+import inspect
+import os
+
 import jug.jug
 from jug.tests.utils import simple_execute
 from jug.backends.dict_store import dict_store
 from .task_reset import task_reset
 from jug.task import describe
 from nose.tools import with_setup
+
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
+
 
 def remove_files(flist, dlist):
     def teardown():
@@ -23,7 +31,7 @@ def remove_files(flist, dlist):
 
 @task_reset
 def test_describe():
-    jugfile = 'jug/tests/jugfiles/simple.py'
+    jugfile = os.path.join(_jugdir, 'simple.py')
     store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
     t = space['vals'][0]
@@ -33,7 +41,7 @@ def test_describe():
 @remove_files(['x.pkl', 'x.meta.yaml', 'x.meta.json'], ['testing_TO_DELETE.jugdata'])
 @task_reset
 def test_describe():
-    jugfile = 'jug/tests/jugfiles/write_with_meta.py'
+    jugfile = os.path.join(_jugdir, 'write_with_meta.py')
     store, space = jug.jug.init(jugfile, 'testing_TO_DELETE.jugdata')
     simple_execute()
     x = space['x']

--- a/jug/tests/test_jug_check.py
+++ b/jug/tests/test_jug_check.py
@@ -1,3 +1,6 @@
+import inspect
+import os
+
 import jug.jug
 import jug.task
 from jug.task import Task
@@ -8,6 +11,11 @@ from jug.options import Options, default_options
 
 import random
 jug.jug.silent = True
+
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
+
 
 def test_jug_check():
     N = 16
@@ -44,7 +52,7 @@ def test_jug_check():
 
 @task_reset
 def test_tasklet():
-    jugfile = 'jug/tests/jugfiles/sleep_until_tasklet.py'
+    jugfile = os.path.join(_jugdir, 'sleep_until_tasklet.py')
     store, space = jug.jug.init(jugfile, 'dict_store')
     assert 'four' not in space
     simple_execute()

--- a/jug/tests/test_jug_execute.py
+++ b/jug/tests/test_jug_execute.py
@@ -1,3 +1,6 @@
+import inspect
+import os
+
 import jug.jug
 import jug.task
 from jug.task import Task
@@ -5,6 +8,11 @@ from jug.tests.utils import simple_execute
 from jug.backends.dict_store import dict_store
 import random
 jug.jug.silent = True
+
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
+
 
 def test_jug_execute_simple():
     N = 1024
@@ -47,9 +55,9 @@ def test_aggressive_unload():
     def run_jugfile(jugfile):
         store, space = jug.jug.init(jugfile, 'dict_store')
         execution_loop(alltasks, options)
-    yield run_jugfile, 'jug/tests/jugfiles/tasklet_simple.py'
-    yield run_jugfile, 'jug/tests/jugfiles/tasklets.py'
-    yield run_jugfile, 'jug/tests/jugfiles/barrier_mapreduce.py'
-    yield run_jugfile, 'jug/tests/jugfiles/compound_nonsimple.py'
-    yield run_jugfile, 'jug/tests/jugfiles/slice_task.py'
+    yield run_jugfile, os.path.join(_jugdir, 'tasklet_simple.py')
+    yield run_jugfile, os.path.join(_jugdir, 'tasklets.py')
+    yield run_jugfile, os.path.join(_jugdir, 'barrier_mapreduce.py')
+    yield run_jugfile, os.path.join(_jugdir, 'compound_nonsimple.py')
+    yield run_jugfile, os.path.join(_jugdir, 'slice_task.py')
 

--- a/jug/tests/test_jug_invalidate.py
+++ b/jug/tests/test_jug_invalidate.py
@@ -1,3 +1,6 @@
+import inspect
+import os
+
 from nose.tools import with_setup
 import jug.jug
 import jug.task
@@ -8,6 +11,10 @@ from jug.tests.utils import simple_execute
 from jug.tests.task_reset import task_reset
 import random
 jug.jug.silent = True
+
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
 
 
 @task_reset
@@ -29,10 +36,11 @@ def test_jug_invalidate():
 
 @task_reset
 def test_complex():
-    store, space = jug.jug.init('jug/tests/jugfiles/tasklets.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'tasklets.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
 
-    store, space = jug.jug.init('jug/tests/jugfiles/tasklets.py', store)
+    store, space = jug.jug.init(jugfile, store)
     opts = Options(default_options)
     opts.invalid_name = space['t'].name
     h = space['t'].hash()
@@ -42,7 +50,8 @@ def test_complex():
 
 @task_reset
 def test_cleanup():
-    store, space = jug.jug.init('jug/tests/jugfiles/tasklets.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'tasklets.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     h = space['t'].hash()
     simple_execute()
 

--- a/jug/tests/test_mapreduce.py
+++ b/jug/tests/test_mapreduce.py
@@ -1,3 +1,6 @@
+import inspect
+import os
+
 import numpy as np
 
 import jug.mapreduce
@@ -8,6 +11,11 @@ from jug import value, TaskGenerator
 from jug.tests.task_reset import task_reset
 import jug.utils
 from functools import reduce
+
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
+
 
 def mapper(x):
     return x**2
@@ -63,19 +71,22 @@ def test_break_up():
 
 @task_reset
 def test_empty_mapreduce():
-    store, space = jug.jug.init('jug/tests/jugfiles/empty_mapreduce.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'empty_mapreduce.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
     assert value(space['two']) == []
 
 @task_reset
 def test_taskgenerator_mapreduce():
-    store, space = jug.jug.init('jug/tests/jugfiles/mapreduce_generator.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'mapreduce_generator.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
     assert space['sumtwo'].result == 2*sum(range(10))
 
 @task_reset
 def test_taskgenerator_map():
-    store, space = jug.jug.init('jug/tests/jugfiles/mapgenerator.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'mapgenerator.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
     assert len(value(space['v2s'])) == 16
 

--- a/jug/tests/test_status.py
+++ b/jug/tests/test_status.py
@@ -1,27 +1,37 @@
+import inspect
+import os
+
 from jug.subcommands import status
 from jug.tests.task_reset import task_reset
 from jug.tests.utils import simple_execute
 from jug.options import default_options
 import jug
 
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
+
+
 @task_reset
 def test_nocache():
-    store, space = jug.jug.init('jug/tests/jugfiles/simple.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'simple.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
 
     options = default_options.copy()
     options.jugdir = store
-    options.jugfile = 'jug/tests/jugfiles/simple.py'
+    options.jugfile = jugfile
     options.verbose = 'quiet'
     assert status.status(options) == 8 * 4
 
 @task_reset
 def test_cache():
-    store, space = jug.jug.init('jug/tests/jugfiles/simple.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'simple.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
 
     options = default_options.copy()
     options.jugdir = store
-    options.jugfile = 'jug/tests/jugfiles/simple.py'
+    options.jugfile = jugfile
     options.verbose = 'quiet'
     options.status_mode = 'cached'
     options.status_cache_file = ':memory:'
@@ -32,11 +42,12 @@ def test_cache():
 
 @task_reset
 def test_cache_bvalue():
-    store, space = jug.jug.init('jug/tests/jugfiles/bvalue.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'bvalue.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
 
     options = default_options.copy()
     options.jugdir = store
-    options.jugfile = 'jug/tests/jugfiles/bvalue.py'
+    options.jugfile = jugfile
     options.verbose = 'quiet'
     options.status_mode = 'cached'
     options.status_cache_file = ':memory:'

--- a/jug/tests/test_tasklet.py
+++ b/jug/tests/test_tasklet.py
@@ -1,11 +1,20 @@
+import inspect
+import os
+
 from jug.tests.task_reset import task_reset
 from jug.tests.utils import simple_execute
 from jug import task
 import jug.jug
 
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
+
+
 @task_reset
 def test_tasklets():
-    store, space = jug.jug.init('jug/tests/jugfiles/tasklets.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'tasklets.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
     assert space['t0'].value() == 0
     assert space['t2'].value() == 4
@@ -14,7 +23,8 @@ def test_tasklets():
 
 @task_reset
 def test_iteratetask():
-    store, space = jug.jug.init('jug/tests/jugfiles/iteratetask.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'iteratetask.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
     assert space['t0'].value() == 0
     assert space['t1'].value() == 2
@@ -22,13 +32,15 @@ def test_iteratetask():
 
 @task_reset
 def test_tasklet_dependencies():
-    store, space = jug.jug.init('jug/tests/jugfiles/tasklets.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'tasklets.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     assert not space['t0_2'].can_run()
 
 
 @task_reset
 def test_tasklet_dependencies():
-    store, space = jug.jug.init('jug/tests/jugfiles/slice_task.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'slice_task.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
     assert space['z2'].value() == 0
 

--- a/jug/tests/test_tasks.py
+++ b/jug/tests/test_tasks.py
@@ -1,8 +1,16 @@
+import inspect
+import os
+
 from nose.tools import with_setup
 import jug.task
 from jug.backends.dict_store import dict_store
 from jug.tests.task_reset import task_reset
 from jug.tests.utils import simple_execute
+
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
+
 
 Task = jug.task.Task
 jug.task.Task.store = dict_store()
@@ -264,7 +272,8 @@ def test_unload_recursive_tuple():
 @task_reset
 def test_builtin_function():
     import numpy as np
-    store, space = jug.jug.init('jug/tests/jugfiles/builtin_function.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'builtin_function.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
     a8 = jug.task.value(space['a8'])
     assert np.all(a8 == np.arange(8))

--- a/jug/tests/test_utils_customhash.py
+++ b/jug/tests/test_utils_customhash.py
@@ -1,10 +1,19 @@
+import inspect
+import os
+
 from jug.backends.dict_store import dict_store
 from jug.tests.utils import simple_execute
 from jug.tests.task_reset import task_reset
 import jug.jug
 
+
+_jugdir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+_jugdir = os.path.join(os.path.dirname(_jugdir), 'jugfiles')
+
+
 @task_reset
 def test_w_barrier():
-    store, space = jug.jug.init('jug/tests/jugfiles/custom_hash_function.py', 'dict_store')
+    jugfile = os.path.join(_jugdir, 'custom_hash_function.py')
+    store, space = jug.jug.init(jugfile, 'dict_store')
     simple_execute()
     assert space['hash_called']


### PR DESCRIPTION
Travis tests are currently run on the _uninstalled_ source package because the `jug` directory is found first by Python. This changes Travis to use the installed source instead.

Also, use the absolute path to jug files in tests; this allows testing to be run on an installed package by anyone.