### PR TITLE
Py3k example bugfixes

### DIFF
--- a/examples/decrypt/brute.py
+++ b/examples/decrypt/brute.py
@@ -1,7 +1,8 @@
 import itertools
 from crypt import decode, letters, isgood, preprocess
 
-ciphertext = file('secret.msg').read()
+with open('secret.msg') as f:
+    ciphertext = f.read()
 ciphertext = preprocess(ciphertext)
 
 for p in itertools.product(letters, repeat=5):

--- a/examples/decrypt/jugfile.py
+++ b/examples/decrypt/jugfile.py
@@ -3,7 +3,8 @@ import numpy as np
 from itertools import product, chain
 from crypt import decode, letters, isgood, preprocess
 
-ciphertext = file('secret.msg').read()
+with open('secret.msg') as f:
+    ciphertext = f.read()
 ciphertext = preprocess(ciphertext)
 
 @TaskGenerator

--- a/examples/text/jugfile.py
+++ b/examples/text/jugfile.py
@@ -14,7 +14,8 @@ def get_data(title):
     # In a real example, we would *not* have a cache, of course.
     cache = 'text-data/' + title
     if exists(cache):
-        return str(file(cache).read(), 'utf-8')
+        with open(cache, 'rb') as f:
+            return f.read().decode('utf-8')
 
     title = urllib.parse.quote(title)
     url = 'http://en.wikipedia.org/w/api.php?action=query&prop=revisions&rvprop=content&format=json&titles=' + title
@@ -30,9 +31,8 @@ def get_data(title):
         mkdir('text-data')
     except:
         pass
-    cache = file(cache, 'w')
-    cache.write(text.encode('utf-8'))
-    cache.close()
+    with open(cache, 'wb') as f:
+        f.write(text.encode('utf-8'))
     return text
 
 def isstopword(titlewords, w):
@@ -80,10 +80,11 @@ def divergence(global_counts, nr_documents, counts):
     return specific
 
 counts = []
-for mp in open('MPs.txt'):
-    mp = mp.strip()
-    document = Task(get_data, mp)
-    counts.append(Task(count_words, mp, document))
+with open('MPs.txt', 'rb') as f:
+    for mp in f:
+        mp = mp.decode('utf-8').strip()
+        document = Task(get_data, mp)
+        counts.append(Task(count_words, mp, document))
 avgs = Task(add_counts, counts)
 results = []
 for c in counts:

--- a/examples/text/jugfile.py
+++ b/examples/text/jugfile.py
@@ -1,4 +1,4 @@
-import urllib.request, urllib.error, urllib.parse
+import requests
 from jug import Task
 from collections import defaultdict
 from time import sleep
@@ -17,10 +17,13 @@ def get_data(title):
         with open(cache, 'rb') as f:
             return f.read().decode('utf-8')
 
-    title = urllib.parse.quote(title)
-    url = 'http://en.wikipedia.org/w/api.php?action=query&prop=revisions&rvprop=content&format=json&titles=' + title
-    text = urllib.request.urlopen(url).read()
-    data = json.loads(text)
+    params = {'action': 'query',
+              'prop': 'revisions',
+              'rvprop': 'content',
+              'format': 'json',
+              'titles': title}
+    r = requests.get('http://en.wikipedia.org/w/api.php', params=params)
+    data = json.loads(r.text)
     data = list(data['query']['pages'].values())[0]
     text = data['revisions'][0]['*']
     text = re.sub(r'(?x) \[ [^]] *? \]\]', '', text)

--- a/examples/text/printresults.py
+++ b/examples/text/printresults.py
@@ -5,6 +5,7 @@ jug.init('jugfile', 'jugdata')
 import jugfile
 
 results = jug.task.value(jugfile.results)
-for mp,r in zip(file('MPs.txt'), results):
-    mp = mp.strip()
-    print(mp, ":    ", " ".join(r[:8]))
+with open('MPs.txt') as f:
+    for mp, r in zip(f, results):
+        mp = mp.strip()
+        print(mp, ":    ", " ".join(r[:8]))


### PR DESCRIPTION
The decrypt example did not work on Python 3 because of deprecated functions.

The text example was a mix of Python 2 and Python 3, so it ran on neither one. To simplify things, I just made it use the `requests` library instead, which supports both 2 and 3.

~~Because of merge conflicts, this depends on #19. Sorry.~~