### PR TITLE
Allow options to be passed to jugfile

### DIFF
--- a/jug/options.py
+++ b/jug/options.py
@@ -230,6 +230,7 @@ def parse(cmdlist=None, optionsfile=None):
     cmdline = Options(infile)
 
     parser = optparse.OptionParser(usage=_usage_simple, version=__version__)
+    parser.disable_interspersed_args()
     parser.add_option(
                     '--aggressive-unload',
                     action='store_true',


### PR DESCRIPTION
add disable interspersed_args to make sure extra options are properly passed to the jug file

see:
http://stackoverflow.com/questions/716006/optionparser-supporting-any-option-at-the-end-of-the-command-line