### PR TITLE
ENH Allow specifying a target to restrict what to execute

### DIFF
--- a/jug/jug.py
+++ b/jug/jug.py
@@ -129,6 +129,12 @@ def execution_loop(tasks, options):
 
     if options.debug:
         start_task_set = set([id(t) for t in task.alltasks])
+
+    # If we are running with a target, exclude non-matching tasks
+    if options.execute_target:
+        tasks = [t for t in tasks if t.name.startswith(options.execute_target)]
+        logging.info('Non-matching tasks discarded. Remaining (%s tasks)' % len(tasks))
+
     prevtask = None
     while tasks:
         upnext = [] # tasks that can be run

--- a/jug/jug.py
+++ b/jug/jug.py
@@ -126,7 +126,8 @@ def execution_loop(tasks, options):
 
     # If we are running with a target, exclude non-matching tasks
     if options.execute_target:
-        tasks = [t for t in tasks if t.name.startswith(options.execute_target)]
+        task_matcher = prepare_task_matcher(options.execute_target)
+        tasks = [t for t in tasks if task_matcher(t.name)]
         logging.info('Non-matching tasks discarded. Remaining (%s tasks)' % len(tasks))
 
     prevtask = None

--- a/jug/options.py
+++ b/jug/options.py
@@ -76,6 +76,7 @@ default_options.cleanup_locks_only = False
 default_options.execute_wait_cycle_time_secs = 12
 default_options.execute_nr_wait_cycles = (30*60) // default_options.execute_wait_cycle_time_secs
 default_options.execute_keep_going = False
+default_options.execute_target = None
 
 default_options.status_cache_file = '.jugstatus.sqlite3'
 
@@ -257,6 +258,8 @@ true: you can use --debug mode without --pdb.''')
     parser.add_option('--nr-wait-cycles', action='store', dest='execute_nr_wait_cycles')
     parser.add_option('--keep-going', action='store_true', dest='execute_keep_going', help='For execute: continue after errors')
     parser.add_option('--wait-cycle-time', action='store', dest='execute_wait_cycle_time_secs')
+    parser.add_option('--target', action='store', dest='execute_target',
+                      help="Restrict tasks to execute based on their name")
     options,args = parser.parse_args(cmdlist)
     if not args:
         usage()
@@ -291,6 +294,7 @@ true: you can use --debug mode without --pdb.''')
     _maybe_set('execute_nr_wait_cycles')
     _maybe_set('execute_wait_cycle_time_secs')
     _maybe_set('execute_keep_going')
+    _maybe_set('execute_target')
     _maybe_set('status_cache_clear')
     _maybe_set('status_cache_file')
 

--- a/jug/tests/jugfiles/simple_multiple.py
+++ b/jug/tests/jugfiles/simple_multiple.py
@@ -1,0 +1,18 @@
+from jug import TaskGenerator
+
+@TaskGenerator
+def sum_2(a):
+    return a + 2
+
+@TaskGenerator
+def sum_3(a, b):
+    return a + b + 3
+
+@TaskGenerator
+def subtract(a, b):
+    return a - b
+
+vals = list(range(8))
+vals = [sum_2(v) for v in vals]
+vals = [sum_3(v, v) for v in vals]
+vals = [subtract(v, 5) for v in vals]

--- a/jug/tests/test_jug_execute.py
+++ b/jug/tests/test_jug_execute.py
@@ -6,6 +6,7 @@ import jug.task
 from jug.task import Task
 from jug.tests.utils import simple_execute
 from jug.backends.dict_store import dict_store
+from jug.options import default_options
 from .task_reset import task_reset
 
 import random
@@ -64,3 +65,32 @@ def test_aggressive_unload():
     yield run_jugfile, os.path.join(_jugdir, 'compound_nonsimple.py')
     yield run_jugfile, os.path.join(_jugdir, 'slice_task.py')
 
+@task_reset
+def test_target_exact():
+    from jug.jug import execution_loop
+    from jug.task import alltasks
+    options = default_options.copy()
+    options.jugfile = os.path.join(_jugdir, 'simple.py')
+    # Test if restricting to this target we skip the other tasks
+    options.execute_target = "simple.double"
+
+    store, space = jug.jug.init(options.jugfile, 'dict_store')
+    execution_loop(alltasks, options)
+
+    assert len(store.store) < len(alltasks)
+    assert len(store.store) == 8
+
+@task_reset
+def test_target_wild():
+    from jug.jug import execution_loop
+    from jug.task import alltasks
+    options = default_options.copy()
+    options.jugfile = os.path.join(_jugdir, 'simple_multiple.py')
+    # Test if restricting to this target we skip the other tasks
+    options.execute_target = "simple_multiple.sum_"
+
+    store, space = jug.jug.init(options.jugfile, 'dict_store')
+    execution_loop(alltasks, options)
+
+    assert len(store.store) < len(alltasks)
+    assert len(store.store) == 16

--- a/jug/utils.py
+++ b/jug/utils.py
@@ -22,6 +22,8 @@
 
 
 import os
+import re
+from functools import partial
 
 from .task import Task, TaskGenerator, Tasklet, value
 
@@ -153,6 +155,23 @@ def timed_path(path):
         A task equivalent to ``(lambda: ipath)``.
     '''
     return CustomHash(path, hash_with_mtime_size)
+
+
+def prepare_task_matcher(pattern):
+    if re.match(r'/.*/', pattern):
+        # Looks like a regular expression
+        regex = re.compile(pattern.strip('/'))
+
+    elif '.' in pattern:
+        # Looks like a full task name
+        regex = pattern.replace('.', '\\.')
+
+    else:
+        # A bare function name perhaps?
+        regex = re.compile(r'\.' + pattern)
+
+    return partial(re.search, regex)
+
 
 @TaskGenerator
 def jug_execute(args, check_exit=True, run_after=None):


### PR DESCRIPTION
I love jug's "pick work from pool" concept but sometimes some of the tasks are simply too heterogeneous to be clumped together. It forces me to split jugfiles into smaller units.

By being possible to specify a target I can easily split work across different `jug execute` instances which run in different conditions/hardware/limits/...

Example:

    jug execute --target jugfile.mem_heavy
    jug execute --target jugfile.cpu_heavy
    jug execute --target jugfile.low_       # anything starting with this prefix