### PR TITLE
Introduce ability to extend jug with user defined commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.6"
 sudo: false
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6* ]]; then pip install importlib; fi
   - pip install numpy
   - pip install six
   - pip install redis

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@ version 1.4.0+git
 	* Fix bug in finding config files
 	* Improved --debug mode: check for unsupported recursive task creation
 	* Add invalidate() to shell environment
+	* Use ~/.config/jug/jugrc as configuration file
+	* Add experimental support for extensible commands, use
+	~/.config/jug/jug_user_commands.py
 
 version 1.4.0 Tue Jan 3 2017 by luispedro
 	* Fix bug with writing very large objects to disk

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ version 1.4.0+git
 	* Use ~/.config/jug/jugrc as configuration file
 	* Add experimental support for extensible commands, use
 	~/.config/jug/jug_user_commands.py
+	* jugrc: execute_wait_cycle_time_secs is now execute_wait_cycle_time
 
 version 1.4.0 Tue Jan 3 2017 by luispedro
 	* Fix bug with writing very large objects to disk

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ from jug.jug_version import __version__ as jug_version
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
         'sphinx.ext.autodoc',
-        'sphinx.ext.pngmath',
+        'sphinx.ext.imgmath',
         'sphinx.ext.autosummary',
         'numpydoc',
         'sphinx.ext.intersphinx',

--- a/docs/source/subcommands.rst
+++ b/docs/source/subcommands.rst
@@ -73,3 +73,11 @@ cleanup
 
 Removes all elements in the store that are not used by your jugfile.
 
+
+Extending Subcommands
+---------------------
+
+.. note::
+    This feature is still experimental
+
+.. automodule:: jug.subcommands

--- a/docs/source/writeabackend.rst
+++ b/docs/source/writeabackend.rst
@@ -22,8 +22,8 @@ Your backend should support a similar scheme.
 How to write a backend
 ----------------------
 
-You can start with the file ``jug/backends/generic.py`` which provides a
+You can start with the file ``jug/backends/base.py`` which provides a
 template with documentation. Implement the functions in there.
 
-.. automodule:: jug.backends.generic
-    :members: generic_backend, generic_lock
+.. automodule:: jug.backends.base
+    :members: base_store, base_lock

--- a/jug/backends/dict_store.py
+++ b/jug/backends/dict_store.py
@@ -167,7 +167,7 @@ class dict_store(base_store):
 
     def close(self):
         if self.backend is not None:
-            pickle.dump(self.store, file(self.backend, 'w'))
+            pickle.dump(self.store, open(self.backend, 'w'))
             self.backend = None
     __del__ = close
 

--- a/jug/jug.py
+++ b/jug/jug.py
@@ -268,8 +268,8 @@ def main(argv=None):
     if options.subcommand not in ('status', 'execute', 'webstatus', 'test-jug'):
         store, jugspace = init(options.jugfile, options.jugdir)
 
-    from .subcommands import subcommand
-    subcommand.run(options.subcommand, options=options, store=store, jugspace=jugspace)
+    from .subcommands import cmdapi
+    cmdapi.run(options.subcommand, options=options, store=store, jugspace=jugspace)
 
     if store is not None:
         store.close()

--- a/jug/jug.py
+++ b/jug/jug.py
@@ -165,8 +165,8 @@ def execution_loop(tasks, options):
                     break
             if upnext:
                 break
-            logging.info('waiting %s secs for an open task...' % options.execute_wait_cycle_time_secs)
-            sleep(int(options.execute_wait_cycle_time_secs))
+            logging.info('waiting %s secs for an open task...' % options.execute_wait_cycle_time)
+            sleep(int(options.execute_wait_cycle_time))
         if not upnext:
             logging.info('No tasks can be run!')
             break

--- a/jug/jug.py
+++ b/jug/jug.py
@@ -261,15 +261,15 @@ def main(argv=None):
     from .options import parse
     if argv is None:
         from sys import argv
-    options = parse(argv[1:])
+    options = parse()
     jugspace = None
     store = None
 
-    if options.cmd not in ('status', 'execute', 'webstatus', 'test-jug'):
+    if options.subcommand not in ('status', 'execute', 'webstatus', 'test-jug'):
         store, jugspace = init(options.jugfile, options.jugdir)
 
     from .subcommands import subcommand
-    subcommand.run(options.cmd, options=options, store=store, jugspace=jugspace)
+    subcommand.run(options.subcommand, options=options, store=store, jugspace=jugspace)
 
     if store is not None:
         store.close()

--- a/jug/mapreduce.py
+++ b/jug/mapreduce.py
@@ -8,7 +8,7 @@ mapreduce: Build tasks that follow a map-reduce pattern.
 '''
 
 
-from .jug import Task
+from .task import Task
 from .utils import identity
 from .hash import hash_one
 

--- a/jug/options.py
+++ b/jug/options.py
@@ -67,7 +67,7 @@ default_options.aggressive_unload = False
 default_options.invalid_name = None
 default_options.argv = None
 default_options.print_out = six.print_
-default_options.status_mode = 'no-cached'
+default_options.status_cache = False
 default_options.status_cache_clear = False
 default_options.short = False
 default_options.pdb = False
@@ -130,7 +130,7 @@ def read_configuration_file(fp=None):
     attempt('main', 'jugdir', 'jugdir')
     attempt('main', 'jugfile', 'jugfile')
 
-    attempt('status', 'cache', 'status_mode')
+    attempt('status', 'cache', 'status_cache')
 
     attempt('cleanup', 'locks-only', 'cleanup_locks_only', bool)
 
@@ -228,9 +228,7 @@ def parse(args=None, optionsfile=None):
     # of the last argument. Still not sure how to fix this.
     options = parser.parse_args(args)
 
-    # FIXME This shouldn't be necessary. Use add_argument(dest="status_mode"
-    #   with 'choices=["cached", "no-cached"])' or simply refactor to options.cached (bool)
-    cmdline.status_mode = 'cached' if vars(options).get("status_mode", None) else 'no-cached'
+    cmdline.status_cache = True if vars(options).get("status_cache", None) else False
 
     # FIXME This entire updating mechanism needs to be replaced by something
     # that preserves options set in argparse's parsers, otherwise subcommands

--- a/jug/options.py
+++ b/jug/options.py
@@ -88,7 +88,7 @@ def key_to_option(s):
 def read_configuration_file(fp=None, default_options=None):
     '''
     options = read_configuration_file(fp='~/.config/jugrc',
-                                      default_options={"execute_keep_going": True})
+                                      default_options={'':'', ...})
 
     Parse configuration file.
 
@@ -96,6 +96,9 @@ def read_configuration_file(fp=None, default_options=None):
     ----------
     fp : inputfile, optional
         File to read. If not given, use
+    default_options: dictionary, optional
+        Dictionary with the default values for all command-line arguments.
+        Used to convert settings in the config file to the correct object type.
     '''
     inifile = Options(default_options)
 
@@ -123,7 +126,7 @@ def read_configuration_file(fp=None, default_options=None):
             else:
                 new_name = "{0}_{1}".format(key_to_option(section), key_to_option(key))
 
-            # Get type of default value if a default value exists
+            # Get the type of the default value if a default value exists
             if default_options is not None:
                 old_value = getattr(default_options, new_name, None)
                 if old_value is not None:
@@ -187,20 +190,19 @@ def parse(args=None, optionsfile=None):
     Parse the command line options and set the option variables.
     '''
     import argparse
-    from .subcommands import subcommand
+    from .subcommands import cmdapi
 
     if len(sys.argv) == 1:
-        subcommand.usage()
+        cmdapi.usage()
 
     parser = argparse.ArgumentParser(
-        description=subcommand.usage(_print=False, exit=False),
+        description=cmdapi.usage(_print=False, exit=False),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    define_options(parser)
 
     sub = parser.add_subparsers(dest="subcommand", help=argparse.SUPPRESS)
     sub.required = True
-    subparsers = subcommand.get_subcommand_parsers(sub)
+    subparsers = cmdapi.get_subcommand_parsers(sub)
 
     # NOTE The parents=[parent] feature of argparse is severely broken
     # causing dependency loops in required arguments.
@@ -210,7 +212,6 @@ def parse(args=None, optionsfile=None):
 
     argopts = parser.parse_args(args)
 
-    default_options.update(subcommand.default_options)
     inifile = read_configuration_file(optionsfile, default_options=default_options)
     # Priority is: user-supplied command line, config file, default options
     cmdline = Options(inifile)

--- a/jug/subcommands/__init__.py
+++ b/jug/subcommands/__init__.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2008-2015, Luis Pedro Coelho <luis@luispedro.org>
+# vim: set ts=4 sts=4 sw=4 expandtab smartindent:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+"""Subcommands are now implemented using a modular design that allows extending
+jug with additional commands.
+This API is currently in experimental stage and may change in the future.
+
+The following serves as an example of how to extend jug's commands.
+
+Lets assume you wanted to create a custom report and have it available as::
+
+    $ jug my-fancy-report
+
+First you will need to implement a function with the following signature::
+
+    def fancyreport_func(*args, **kwargs):
+        "Produces a fancy report of my results"
+        ...
+
+The first line of the docstring is important as it will be shown as part of the
+jug usage help page.
+
+Then add your fancyreport extra commands to ``~/.config/jug/jug_user_commands.py``
+registering your commands via::
+
+    from jug.subcommands import subcommand
+    #                  <command-name>  <function to call>
+    subcommand.register("my-fancy-report", fancyreport_func)
+
+Finally you should know that your function will receive the following objects:
+
+* ``options``  - object representing command-line and user options
+* ``store``    - backend object reponsible for handling jobs
+* ``jugspace`` - a namespace of jug internal variables (better not touch)
+
+additional objects may be introduced in the future so make sure your function
+uses ``*args, **kwargs`` to maintain compatibility.
+
+"""
+
+__all__ = [
+    'SubCommand',
+    'SubCommandManager',
+    'SubCommandError',
+    'NoSuchCommandError',
+]
+
+import importlib
+import logging
+import os
+import pkgutil
+import sys
+import traceback
+
+
+class SubCommandError(Exception):
+    "Exception raised when a subcommand doesn't respect the API"
+
+
+class NoSuchCommandError(Exception):
+    "Exception raised when a subcommand doesn't respect the API"
+
+
+def _get_helptext(command):
+    "First line of the docstring is to be shown on the help/usage text"
+    try:
+        return command.__doc__.splitlines()[0]
+    except AttributeError:
+        raise SubCommandError("Command '%s' is missing a documentation string" % (command,))
+
+
+def _invalid_module(module, e):
+    raise SubCommandError(
+        """Invalid subcommand structure.
+Please make sure that the subcommand(s) '%s' conform(s) to the API.
+
+    help(jug.subcommands) for more information
+
+Original error was:
+%s
+""" % (module, e))
+
+
+class SubCommandManager:
+    def __init__(self):
+        self._commands = {}
+
+    def register(self, name, callback):
+        if name in self._commands and self._commands[name] != callback:
+            logging.warning("Jug: command: '%s' will be overriden with code from '%s'" % (name, callback.__name__))
+
+        self._commands[name] = callback
+
+    def get(self, command):
+        if command not in self._commands:
+            self._load_commands(command)
+
+        try:
+            return self._commands[command]
+        except KeyError:
+            raise NoSuchCommandError("Unknown subcommand '%s'" % (command,))
+
+    def run(self, command, *args, **kwargs):
+        """Execute subcommand
+        """
+        try:
+            cmd = subcommand.get(command)
+        except NoSuchCommandError as e:
+            subcommand.usage(error=e)
+
+        try:
+            return cmd(*args, **kwargs)
+        except TypeError as e:
+            if "unexpected keyword" in str(e):
+                _invalid_module(command, e)
+
+            traceback.print_exc(file=sys.stderr)
+
+            subcommand.usage(error=e)
+
+    def usage(self, error='', exit=True, _print=True, *args, **kwargs):
+        "Shows help/usage information"
+
+        usage_text = ['''\
+jug SUBCOMMAND [JUGFILE] [OPTIONS...]
+
+Docs: https://jug.readthedocs.io/
+Copyright: 2008-2017, Luis Pedro Coelho
+
+Subcommands
+-----------
+''']
+        self._load_commands()
+
+        for name, command in sorted(self._commands.items()):
+            usage_text.append("   %-15s %s" % (name + ":", _get_helptext(command)))
+
+        if error:
+            usage_text.append("")
+            usage_text.append(str(error))
+
+        message = "\n".join(usage_text) + "\n\n"
+
+        if _print:
+            sys.stdout.write(message)
+
+        if exit:
+            sys.exit(1)
+
+        return message
+
+    def _try_import(self, module):
+        try:
+            importlib.import_module(module)
+        except Exception as e:
+            logging.warning("Couldn't load subcommand '%s' with error '%s'", module, e)
+
+    def _load_commands(self, stop_on_command=None):
+        """Load all modules in jug's subcommands and user's jug folder
+
+        If stop_on_command is given the function will return True as soon as
+        a matching command is found
+        """
+        for _, name, _ in pkgutil.iter_modules(__path__):
+            module = __name__ + '.' + name
+
+            self._try_import(module)
+
+            if stop_on_command in self._commands:
+                return True
+
+        self._load_user_commands()
+
+    def _load_user_commands(self, user_path="~/.config/jug/"):
+        user_path = os.path.expanduser(user_path)
+        if os.path.isdir(user_path):
+            if user_path not in sys.path:
+                sys.path.insert(0, user_path)
+
+            self._try_import("jug_user_commands")
+
+
+subcommand = SubCommandManager()

--- a/jug/subcommands/check.py
+++ b/jug/subcommands/check.py
@@ -24,7 +24,7 @@
 import sys
 
 from .. import task
-from . import subcommand
+from . import SubCommand
 
 __all__ = [
     'check',
@@ -32,7 +32,7 @@ __all__ = [
 ]
 
 
-def check(store, options, *args, **kwargs):
+class CheckCommand(SubCommand):
     '''Returns 0 if all tasks are finished. 1 otherwise.
 
     check(store, options)
@@ -45,10 +45,13 @@ def check(store, options, *args, **kwargs):
             backend to use
     options : jug options
     '''
-    sys.exit(_check_or_sleep_until(store, False))
+    name = "check"
+
+    def run(self, store, options, *args, **kwargs):
+        sys.exit(_check_or_sleep_until(store, False))
 
 
-def sleep_until(store, options, *args, **kwargs):
+class SleepUntilCommand(SubCommand):
     '''Wait until all tasks are done, then exit.
 
     sleep_until(store, options)
@@ -62,7 +65,10 @@ def sleep_until(store, options, *args, **kwargs):
     options : jug options
         ignored
     '''
-    sys.exit(_check_or_sleep_until(store, True))
+    name = "sleep-until"
+
+    def run(self, store, options, *args, **kwargs):
+        sys.exit(_check_or_sleep_until(store, True))
 
 
 def _check_or_sleep_until(store, sleep_until):
@@ -85,5 +91,5 @@ def _check_or_sleep_until(store, sleep_until):
     return 0
 
 
-subcommand.register("check", check)
-subcommand.register("sleep-until", sleep_until)
+check = CheckCommand()
+sleep_until = SleepUntilCommand()

--- a/jug/subcommands/check.py
+++ b/jug/subcommands/check.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2008-2015, Luis Pedro Coelho <luis@luispedro.org>
+# vim: set ts=4 sts=4 sw=4 expandtab smartindent:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+import sys
+
+from .. import task
+from . import subcommand
+
+__all__ = [
+    'check',
+    'sleep_until',
+]
+
+
+def check(store, options, *args, **kwargs):
+    '''Returns 0 if all tasks are finished. 1 otherwise.
+
+    check(store, options)
+
+    Executes check subcommand
+
+    Parameters
+    ----------
+    store : jug.backend
+            backend to use
+    options : jug options
+    '''
+    sys.exit(_check_or_sleep_until(store, False))
+
+
+def sleep_until(store, options, *args, **kwargs):
+    '''Wait until all tasks are done, then exit.
+
+    sleep_until(store, options)
+
+    Execute sleep-until subcommand
+
+    Parameters
+    ----------
+    store : jug.backend
+            backend to use
+    options : jug options
+        ignored
+    '''
+    sys.exit(_check_or_sleep_until(store, True))
+
+
+def _check_or_sleep_until(store, sleep_until):
+    tasks = task.alltasks
+    active = set(tasks)
+    for t in reversed(tasks):
+        if t not in active:
+            continue
+        while not t.can_load(store):
+            if sleep_until:
+                from time import sleep
+                sleep(12)
+            else:
+                return 1
+        for dep in task.recursive_dependencies(t):
+            try:
+                active.remove(dep)
+            except KeyError:
+                pass
+    return 0
+
+
+subcommand.register("check", check)
+subcommand.register("sleep-until", sleep_until)

--- a/jug/subcommands/cleanup.py
+++ b/jug/subcommands/cleanup.py
@@ -22,38 +22,40 @@
 #  THE SOFTWARE.
 
 from .. import task
-from . import subcommand
+from . import SubCommand
 
 __all__ = [
     'cleanup'
 ]
 
 
-def cleanup(store, options, *args, **kwargs):
+class CleanupCommand(SubCommand):
     '''Cleanup: remove result files that are not used
 
     cleanup(store, options)
 
     Implement 'cleanup' command
     '''
-    if options.cleanup_locks_only:
-        removed = store.remove_locks()
-    else:
-        tasks = task.alltasks
-        removed = store.cleanup(tasks)
-    options.print_out('Removed %s files' % removed)
+    name = "cleanup"
+
+    def run(self, store, options, *args, **kwargs):
+
+        if options.cleanup_locks_only:
+            removed = store.remove_locks()
+        else:
+            tasks = task.alltasks
+            removed = store.cleanup(tasks)
+        options.print_out('Removed %s files' % removed)
+
+    def parse(self, parser):
+        parser.add_argument('--locks-only',
+                            action='store_const', const=True,
+                            dest='cleanup_locks_only')
+
+    def parse_defaults(self):
+        return {
+            "cleanup_locks_only": False,
+        }
 
 
-def cleanup_options(parser):
-    parser.add_argument('--locks-only',
-                        action='store_const', const=True,
-                        dest='cleanup_locks_only')
-
-    default_values = {
-        "cleanup_locks_only": False,
-    }
-
-    return default_values
-
-
-subcommand.register("cleanup", cleanup, cleanup_options)
+cleanup = CleanupCommand()

--- a/jug/subcommands/cleanup.py
+++ b/jug/subcommands/cleanup.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2008-2015, Luis Pedro Coelho <luis@luispedro.org>
+# vim: set ts=4 sts=4 sw=4 expandtab smartindent:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+from .. import task
+from . import subcommand
+
+__all__ = [
+    'cleanup'
+]
+
+
+def cleanup(store, options, *args, **kwargs):
+    '''Cleanup: remove result files that are not used
+
+    cleanup(store, options)
+
+    Implement 'cleanup' command
+    '''
+    if options.cleanup_locks_only:
+        removed = store.remove_locks()
+    else:
+        tasks = task.alltasks
+        removed = store.cleanup(tasks)
+    options.print_out('Removed %s files' % removed)
+
+
+subcommand.register("cleanup", cleanup)

--- a/jug/subcommands/cleanup.py
+++ b/jug/subcommands/cleanup.py
@@ -44,4 +44,16 @@ def cleanup(store, options, *args, **kwargs):
     options.print_out('Removed %s files' % removed)
 
 
-subcommand.register("cleanup", cleanup)
+def cleanup_options(parser):
+    parser.add_argument('--locks-only',
+                        action='store_const', const=True,
+                        dest='cleanup_locks_only')
+
+    default_values = {
+        "cleanup_locks_only": False,
+    }
+
+    return default_values
+
+
+subcommand.register("cleanup", cleanup, cleanup_options)

--- a/jug/subcommands/count.py
+++ b/jug/subcommands/count.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2008-2015, Luis Pedro Coelho <luis@luispedro.org>
+# vim: set ts=4 sts=4 sw=4 expandtab smartindent:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+from collections import defaultdict
+
+from .. import task
+from ..io import print_task_summary_table
+from . import subcommand
+
+__all__ = [
+    'count',
+]
+
+
+def count(store, options, *args, **kwargs):
+    '''Simply count tasks
+
+    count(store, options)
+
+    Print a count of task names.
+
+    Parameters
+    ----------
+    store : jug backend
+    options : jug options
+    '''
+    task_counts = defaultdict(int)
+    for t in task.alltasks:
+        task_counts[t.name] += 1
+
+    print_task_summary_table(options, [("Count", task_counts)])
+
+
+subcommand.register("count", count)

--- a/jug/subcommands/count.py
+++ b/jug/subcommands/count.py
@@ -25,14 +25,14 @@ from collections import defaultdict
 
 from .. import task
 from ..io import print_task_summary_table
-from . import subcommand
+from . import SubCommand
 
 __all__ = [
     'count',
 ]
 
 
-def count(store, options, *args, **kwargs):
+class CountCommand(SubCommand):
     '''Simply count tasks
 
     count(store, options)
@@ -44,11 +44,14 @@ def count(store, options, *args, **kwargs):
     store : jug backend
     options : jug options
     '''
-    task_counts = defaultdict(int)
-    for t in task.alltasks:
-        task_counts[t.name] += 1
+    name = "count"
 
-    print_task_summary_table(options, [("Count", task_counts)])
+    def run(self, store, options, *args, **kwargs):
+        task_counts = defaultdict(int)
+        for t in task.alltasks:
+            task_counts[t.name] += 1
+
+        print_task_summary_table(options, [("Count", task_counts)])
 
 
-subcommand.register("count", count)
+count = CountCommand()

--- a/jug/subcommands/execute.py
+++ b/jug/subcommands/execute.py
@@ -106,19 +106,31 @@ def execute(options, *args, **kwargs):
 
 
 def execute_options(parser):
-    wait_cycle_time = 12
-
     parser.add_argument('--wait-cycle-time', action='store', dest='execute_wait_cycle_time_secs',
-                        metavar='WAIT_CYCLE_TIME_SECS', default=wait_cycle_time,
+                        metavar='WAIT_CYCLE_TIME_SECS', type=int,
                         help="How long to wait in each cycle (in seconds)")
-    parser.add_argument('--nr-wait-cycles', action='store', dest='execute_nr_wait_cycles',
-                        metavar='NR_WAIT_CYCLES', default=(30 * 60) // wait_cycle_time,
+    parser.add_argument('--nr-wait-cycles', action='store',
+                        dest='execute_nr_wait_cycles',
+                        metavar='NR_WAIT_CYCLES', type=int,
                         help="How many wait cycles to do")
     parser.add_argument('--target', action='store', dest='execute_target',
-                        metavar='TARGET', default=None,
+                        metavar='TARGET',
                         help="Restrict tasks to execute based on their name")
-    parser.add_argument('--keep-going', action='store_true', dest='execute_keep_going',
+    parser.add_argument('--keep-going',
+                        action='store_const', const=True,
+                        dest='execute_keep_going',
                         help='Continue after errors')
+
+    wait_cycle_time = 12
+
+    default_values = {
+        "execute_keep_going": False,
+        "execute_target": None,
+        "execute_wait_cycle_time_secs": wait_cycle_time,
+        "execute_nr_wait_cycles": (30 * 60) // wait_cycle_time,
+    }
+
+    return default_values
 
 
 subcommand.register("execute", execute, execute_options)

--- a/jug/subcommands/execute.py
+++ b/jug/subcommands/execute.py
@@ -94,7 +94,7 @@ def execute(options, *args, **kwargs):
         if after == previous:
             from time import sleep
             noprogress += 1
-            sleep(int(options.execute_wait_cycle_time_secs))
+            sleep(int(options.execute_wait_cycle_time))
         else:
             noprogress = 0
     else:
@@ -106,8 +106,8 @@ def execute(options, *args, **kwargs):
 
 
 def execute_options(parser):
-    parser.add_argument('--wait-cycle-time', action='store', dest='execute_wait_cycle_time_secs',
-                        metavar='WAIT_CYCLE_TIME_SECS', type=int,
+    parser.add_argument('--wait-cycle-time', action='store', dest='execute_wait_cycle_time',
+                        metavar='WAIT_CYCLE_TIME', type=int,
                         help="How long to wait in each cycle (in seconds)")
     parser.add_argument('--nr-wait-cycles', action='store',
                         dest='execute_nr_wait_cycles',
@@ -126,7 +126,7 @@ def execute_options(parser):
     default_values = {
         "execute_keep_going": False,
         "execute_target": None,
-        "execute_wait_cycle_time_secs": wait_cycle_time,
+        "execute_wait_cycle_time": wait_cycle_time,
         "execute_nr_wait_cycles": (30 * 60) // wait_cycle_time,
     }
 

--- a/jug/subcommands/execute.py
+++ b/jug/subcommands/execute.py
@@ -105,4 +105,20 @@ def execute(options, *args, **kwargs):
     jug_hook('execute.finished_post_status')
 
 
-subcommand.register("execute", execute)
+def execute_options(parser):
+    wait_cycle_time = 12
+
+    parser.add_argument('--wait-cycle-time', action='store', dest='execute_wait_cycle_time_secs',
+                        metavar='WAIT_CYCLE_TIME_SECS', default=wait_cycle_time,
+                        help="How long to wait in each cycle (in seconds)")
+    parser.add_argument('--nr-wait-cycles', action='store', dest='execute_nr_wait_cycles',
+                        metavar='NR_WAIT_CYCLES', default=(30 * 60) // wait_cycle_time,
+                        help="How many wait cycles to do")
+    parser.add_argument('--target', action='store', dest='execute_target',
+                        metavar='TARGET', default=None,
+                        help="Restrict tasks to execute based on their name")
+    parser.add_argument('--keep-going', action='store_true', dest='execute_keep_going',
+                        help='Continue after errors')
+
+
+subcommand.register("execute", execute, execute_options)

--- a/jug/subcommands/execute.py
+++ b/jug/subcommands/execute.py
@@ -108,13 +108,17 @@ class ExecuteCommand(SubCommand):
         jug_hook('execute.finished_post_status')
 
     def parse(self, parser):
+        defaults = self.parse_defaults()
+
         parser.add_argument('--wait-cycle-time', action='store', dest='execute_wait_cycle_time',
                             metavar='WAIT_CYCLE_TIME', type=int,
-                            help="How long to wait in each cycle (in seconds)")
+                            help=("How long to wait in each cycle (in seconds) "
+                                  "(Default: {execute_wait_cycle_time})".format(**defaults)))
         parser.add_argument('--nr-wait-cycles', action='store',
                             dest='execute_nr_wait_cycles',
                             metavar='NR_WAIT_CYCLES', type=int,
-                            help="How many wait cycles to do")
+                            help=("How many wait cycles to do "
+                                  "(Default: {execute_nr_wait_cycles})".format(**defaults)))
         parser.add_argument('--target', action='store', dest='execute_target',
                             metavar='TARGET',
                             help="Restrict tasks to execute based on their name")

--- a/jug/subcommands/execute.py
+++ b/jug/subcommands/execute.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2008-2015, Luis Pedro Coelho <luis@luispedro.org>
+# vim: set ts=4 sts=4 sw=4 expandtab smartindent:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+from collections import defaultdict
+import logging
+import sys
+
+from .. import task
+from ..hooks import jug_hook, register_hook, register_hook_once
+from ..io import print_task_summary_table
+from ..jug import init
+from . import subcommand
+
+
+__all__ = [
+    'execute'
+]
+
+
+def _sigterm(_, __):
+    sys.exit(1)
+
+
+def _log_loadable(t):
+    logging.info('Loadable {0}...'.format(t.name))
+
+
+class TaskStats(object):
+    def __init__(self):
+        self.loaded = defaultdict(int)
+        self.executed = defaultdict(int)
+        register_hook('execute.task-loadable', self.loadable)
+        register_hook('execute.task-executed1', self.executed1)
+
+    def loadable(self, t):
+        self.loaded[t.name] += 1
+
+    def executed1(self, t):
+        self.executed[t.name] += 1
+
+
+def execute(options, *args, **kwargs):
+    '''Execute tasks
+
+    execute(options)
+
+    Implement 'execute' command
+    '''
+    from signal import signal, SIGTERM
+    from ..jug import execution_loop
+
+    signal(SIGTERM, _sigterm)
+    tasks = task.alltasks
+    tstats = TaskStats()
+    store = None
+    register_hook_once('execute.task-loadable', '_log_loadable', _log_loadable)
+
+    nr_wait_cycles = int(options.execute_nr_wait_cycles)
+    noprogress = 0
+    while noprogress < nr_wait_cycles:
+        del tasks[:]
+        store, jugspace = init(options.jugfile, options.jugdir, store=store)
+        if options.debug:
+            for t in tasks:
+                # Trigger hash computation:
+                t.hash()
+
+        previous = sum(tstats.executed.values())
+        execution_loop(tasks, options)
+        after = sum(tstats.executed.values())
+        done = not jugspace.get('__jug__hasbarrier__', False)
+        if done:
+            break
+        if after == previous:
+            from time import sleep
+            noprogress += 1
+            sleep(int(options.execute_wait_cycle_time_secs))
+        else:
+            noprogress = 0
+    else:
+        logging.info('No tasks can be run!')
+
+    jug_hook('execute.finished_pre_status')
+    print_task_summary_table(options, [("Executed", tstats.executed), ("Loaded", tstats.loaded)])
+    jug_hook('execute.finished_post_status')
+
+
+subcommand.register("execute", execute)

--- a/jug/subcommands/internal_validation.py
+++ b/jug/subcommands/internal_validation.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2008-2015, Luis Pedro Coelho <luis@luispedro.org>
+# vim: set ts=4 sts=4 sw=4 expandtab smartindent:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+from os import path
+import logging
+from . import subcommand
+
+__all__ = [
+    'internal_validation',
+]
+
+# NOTE This module and function were originally called test_jug however
+# after refactoring to subcommands nose would pick this module as a test and
+# run it creating a test recursion.
+#
+# For this reason this module was renamed to internal_validation
+
+def internal_validation(*args, **kwargs):
+    '''Run jug test suite (internal validation)
+    '''
+    try:
+        import nose
+    except ImportError:
+        logging.critical('jug test requires nose library')
+        return
+    currentdir = path.dirname(__file__)
+    updir = path.join(currentdir, '..')
+    argv = ['', '--exe', '-w', updir]
+    argv.append('--verbose')
+    return nose.run('jug', argv=argv)
+
+
+subcommand.register("test-jug", internal_validation)

--- a/jug/subcommands/internal_validation.py
+++ b/jug/subcommands/internal_validation.py
@@ -23,7 +23,7 @@
 
 from os import path
 import logging
-from . import subcommand
+from . import SubCommand
 
 __all__ = [
     'internal_validation',
@@ -35,19 +35,23 @@ __all__ = [
 #
 # For this reason this module was renamed to internal_validation
 
-def internal_validation(*args, **kwargs):
+
+class InternalValidationCommand(SubCommand):
     '''Run jug test suite (internal validation)
     '''
-    try:
-        import nose
-    except ImportError:
-        logging.critical('jug test requires nose library')
-        return
-    currentdir = path.dirname(__file__)
-    updir = path.join(currentdir, '..')
-    argv = ['', '--exe', '-w', updir]
-    argv.append('--verbose')
-    return nose.run('jug', argv=argv)
+    name = "test-jug"
+
+    def run(self, *args, **kwargs):
+        try:
+            import nose
+        except ImportError:
+            logging.critical('jug test requires nose library')
+            return
+        currentdir = path.dirname(__file__)
+        updir = path.join(currentdir, '..')
+        argv = ['', '--exe', '-w', updir]
+        argv.append('--verbose')
+        return nose.run('jug', argv=argv)
 
 
-subcommand.register("test-jug", internal_validation)
+internal_validation = InternalValidationCommand()

--- a/jug/subcommands/invalidate.py
+++ b/jug/subcommands/invalidate.py
@@ -83,4 +83,10 @@ def invalidate(store, options, *args, **kwargs):
         print_task_summary_table(options, [("Invalidated", task_counts)])
 
 
-subcommand.register("invalidate", invalidate)
+def invalidate_options(parser):
+    parser.add_argument('--invalid', required=True, action='store',
+                        dest='invalid_name',
+                        help='Task name to invalidate')
+
+
+subcommand.register("invalidate", invalidate, invalidate_options)

--- a/jug/subcommands/invalidate.py
+++ b/jug/subcommands/invalidate.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2008-2015, Luis Pedro Coelho <luis@luispedro.org>
+# vim: set ts=4 sts=4 sw=4 expandtab smartindent:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+from collections import defaultdict
+
+from ..utils import prepare_task_matcher
+from .. import task
+from ..io import print_task_summary_table
+from . import subcommand
+
+__all__ = [
+    'invalidate'
+]
+
+
+def invalidate(store, options, *args, **kwargs):
+    '''Invalidate the results of a task
+
+    invalidate(store, options)
+
+    Implements 'invalidate' command
+
+    Parameters
+    ----------
+    store : jug.backend
+    options : options object
+        Most relevant option is `invalid_name`, a string  with the exact (i.e.,
+        module qualified) name of function to invalidate
+    '''
+    invalid_name = options.invalid_name
+    tasks = task.alltasks
+    cache = {}
+
+    task_matcher = prepare_task_matcher(invalid_name)
+
+    def isinvalid(t):
+        if isinstance(t, task.Tasklet):
+            return isinvalid(t.base)
+        h = t.hash()
+        if h in cache:
+            return cache[h]
+        if task_matcher(t.name):
+            cache[h] = True
+            return True
+        for dep in t.dependencies():
+            if isinvalid(dep):
+                cache[h] = True
+                return True
+        cache[h] = False
+        return False
+
+    invalid = list(filter(isinvalid, tasks))
+    if not invalid:
+        options.print_out('No results invalidated.')
+        return
+    task_counts = defaultdict(int)
+    for t in invalid:
+        if store.remove(t.hash()):
+            task_counts[t.name] += 1
+    if sum(task_counts.values()) == 0:
+        options.print_out('Tasks invalidated, but no results removed')
+    else:
+        print_task_summary_table(options, [("Invalidated", task_counts)])
+
+
+subcommand.register("invalidate", invalidate)

--- a/jug/subcommands/shell.py
+++ b/jug/subcommands/shell.py
@@ -23,6 +23,8 @@
 
 
 from ..task import value
+from . import subcommand
+
 
 def load_all(jugspace, local_ns):
     '''
@@ -30,13 +32,15 @@ def load_all(jugspace, local_ns):
 
     Loads the result of all tasks.
     '''
-    for k,v in jugspace.items():
+    for k, v in jugspace.items():
         # ignore objects name like __this__
-        if k.startswith('__') and k.endswith('__'): continue
+        if k.startswith('__') and k.endswith('__'):
+            continue
         try:
             local_ns[k] = value(v)
         except Exception as e:
             print('Error while loading %s: %s' % (k, e))
+
 
 _ipython_not_found_msg = '''\
 jug: Error: could not import IPython libraries
@@ -56,6 +60,7 @@ Available jug functions:
 Enjoy...
 '''
 
+
 def invalidate(tasklist, reverse, task):
     if not reverse:
         print("Building task DAG... (only performed once)")
@@ -73,8 +78,10 @@ def invalidate(tasklist, reverse, task):
         d.invalidate()
         queue.extend([t for t in reverse.get(id(d), []) if id(t) not in seen])
 
-def shell(store, options, jugspace):
-    '''
+
+def shell(store, options, jugspace, *args, **kwargs):
+    '''Run a shell after initialization
+
     shell(store, options, jugspace)
 
     Implement 'shell' command.
@@ -83,7 +90,7 @@ def shell(store, options, jugspace):
     '''
     try:
         import IPython
-        if IPython.version_info[0]>=1:
+        if IPython.version_info[0] >= 1:
             from IPython.terminal.embed import InteractiveShellEmbed
             from IPython.terminal.ipapp import load_default_config
         else:
@@ -108,11 +115,12 @@ def shell(store, options, jugspace):
         Loads all task results.
         '''
         load_all(jugspace, local_ns)
-    reverse_cache= {}
+
+    reverse_cache = {}
     def _invalidate(t):
         '''Recursively invalidates its argument, i.e. removes from the store
         results of any task which may (even indirectly) depend on its argument.
-    
+
         This is analogous to the ``jug status`` subcommand.
 
         Parameters
@@ -127,8 +135,8 @@ def shell(store, options, jugspace):
         return invalidate(alltasks, reverse_cache, t)
 
     local_ns = {
-        'load_all' : _load_all,
-        'value' : value,
+        'load_all': _load_all,
+        'value': value,
         'invalidate': _invalidate,
     }
     # This is necessary for some versions of Ipython. See:
@@ -161,3 +169,6 @@ def shell(store, options, jugspace):
         ipshell(module=mod, local_ns=local_ns)
     else:
         ipshell(global_ns=jugspace, local_ns=local_ns)
+
+
+subcommand.register("shell", shell)

--- a/jug/subcommands/status.py
+++ b/jug/subcommands/status.py
@@ -250,17 +250,26 @@ def status(options, *args, **kwargs):
 
 def status_options(parser):
     parser.add_argument('--cache',
-                        action='store_true',
+                        action='store_const', const=True,
                         dest='status_cache',
                         help='Use a cache for faster status [does not update after jugfile changes, though]')
+
     parser.add_argument('--cache-file',
                         action='store', metavar="CACHE_FILE",
                         dest='status_cache_file',
                         help='Name of file to use for status cache. Use with status --cache.')
     parser.add_argument('--clear',
-                        action='store_true',
+                        action='store_const', const=True,
                         dest='status_cache_clear',
                         help='Use with status --cache. Removes the cache file')
+
+    default_values = {
+        "status_cache": False,
+        "status_cache_clear": False,
+        "status_cache_file": ".jugstatus.sqlite3",
+    }
+
+    return default_values
 
 
 subcommand.register("status", status, status_options)

--- a/jug/subcommands/status.py
+++ b/jug/subcommands/status.py
@@ -233,13 +233,13 @@ def status(options, *args, **kwargs):
     ----------
     options : jug options
     '''
-    if options.status_mode == 'cached':
+    if options.status_cache:
         try:
             import sqlite3
         except ImportError:
             from sys import stderr
             stderr.write('Cached status relies on sqlite3. Falling back to non-cached version')
-            options.status_mode = 'no-cache'
+            options.status_cache = False
             return status(options)
         if options.status_cache_clear:
             return _clear_cache(options)
@@ -251,7 +251,7 @@ def status(options, *args, **kwargs):
 def status_options(parser):
     parser.add_argument('--cache',
                         action='store_true',
-                        dest='status_mode',
+                        dest='status_cache',
                         help='Use a cache for faster status [does not update after jugfile changes, though]')
     parser.add_argument('--cache-file',
                         action='store', metavar="CACHE_FILE",

--- a/jug/subcommands/status.py
+++ b/jug/subcommands/status.py
@@ -248,4 +248,19 @@ def status(options, *args, **kwargs):
         return _status_nocache(options)
 
 
-subcommand.register("status", status)
+def status_options(parser):
+    parser.add_argument('--cache',
+                        action='store_true',
+                        dest='status_mode',
+                        help='Use a cache for faster status [does not update after jugfile changes, though]')
+    parser.add_argument('--cache-file',
+                        action='store', metavar="CACHE_FILE",
+                        dest='status_cache_file',
+                        help='Name of file to use for status cache. Use with status --cache.')
+    parser.add_argument('--clear',
+                        action='store_true',
+                        dest='status_cache_clear',
+                        help='Use with status --cache. Removes the cache file')
+
+
+subcommand.register("status", status, status_options)

--- a/jug/subcommands/status.py
+++ b/jug/subcommands/status.py
@@ -251,6 +251,8 @@ class StatusCommand(SubCommand):
             return _status_nocache(options)
 
     def parse(self, parser):
+        defaults = self.parse_defaults()
+
         parser.add_argument('--cache',
                             action='store_const', const=True,
                             dest='status_cache',
@@ -259,7 +261,8 @@ class StatusCommand(SubCommand):
         parser.add_argument('--cache-file',
                             action='store', metavar="CACHE_FILE",
                             dest='status_cache_file',
-                            help='Name of file to use for status cache. Use with status --cache.')
+                            help=('Name of file to use for status cache. Use with status --cache. '
+                                  '(Default: {status_cache_file}'.format(**defaults)))
         parser.add_argument('--clear',
                             action='store_const', const=True,
                             dest='status_cache_clear',

--- a/jug/tests/test_barrier.py
+++ b/jug/tests/test_barrier.py
@@ -2,6 +2,7 @@ import inspect
 import os
 
 import jug.jug
+import jug.subcommands.execute
 from jug.tests.task_reset import task_reset
 from jug.tests.utils import simple_execute
 from jug.options import default_options
@@ -46,7 +47,7 @@ def test_barrier_once():
     options = default_options.copy()
     options.jugdir = 'dict_store'
     options.jugfile = os.path.join(_jugdir, 'wbarrier.py')
-    jug.jug.execute(options)
+    jug.subcommands.execute.execute(options)
     assert 'four' in dir(sys.modules['wbarrier'])
 
 @task_reset

--- a/jug/tests/test_jug_check.py
+++ b/jug/tests/test_jug_check.py
@@ -3,6 +3,7 @@ import os
 
 import jug.jug
 import jug.task
+import jug.subcommands.check
 from jug.task import Task
 from jug.backends.dict_store import dict_store
 from jug.tests.task_reset import task_reset
@@ -31,7 +32,7 @@ def test_jug_check():
     store = dict_store()
     jug.task.Task.store = store
     try:
-        jug.jug.check(store, default_options)
+        jug.subcommands.check.check(store, default_options)
     except SystemExit as e:
         assert e.code == 1
     else:
@@ -41,7 +42,7 @@ def test_jug_check():
     jug.task.alltasks = savedtasks
 
     try:
-        jug.jug.check(store, default_options)
+        jug.subcommands.check.check(store, default_options)
         assert False
     except SystemExit as e:
         assert e.code == 0
@@ -56,5 +57,5 @@ def test_tasklet():
     assert 'four' not in space
     simple_execute()
     store, space = jug.jug.init(jugfile, store)
-    assert jug.jug._check_or_sleep_until(store, False) == 0
-    assert jug.jug._check_or_sleep_until(store, True) == 0
+    assert jug.subcommands.check._check_or_sleep_until(store, False) == 0
+    assert jug.subcommands.check._check_or_sleep_until(store, True) == 0

--- a/jug/tests/test_jug_invalidate.py
+++ b/jug/tests/test_jug_invalidate.py
@@ -3,6 +3,8 @@ import os
 
 import jug.jug
 import jug.task
+import jug.subcommands.invalidate
+import jug.subcommands.cleanup
 from jug.task import Task
 from jug.backends.dict_store import dict_store
 from jug.options import Options, default_options
@@ -28,7 +30,7 @@ def test_jug_invalidate():
 
     opts = Options(default_options)
     opts.invalid_name = setall[0].name
-    jug.jug.invalidate(store, opts)
+    jug.subcommands.invalidate.invalidate(store, opts)
     assert not list(store.store.keys()), list(store.store.keys())
     jug.task.Task.store = dict_store()
 
@@ -43,7 +45,7 @@ def test_complex():
     opts.invalid_name = space['t'].name
     h = space['t'].hash()
     assert store.can_load(h)
-    jug.jug.invalidate(store, opts)
+    jug.subcommands.invalidate.invalidate(store, opts)
     assert not store.can_load(h)
 
 @task_reset
@@ -56,9 +58,9 @@ def test_cleanup():
     opts = Options(default_options)
     opts.cleanup_locks_only = True
     assert store.can_load(h)
-    jug.jug.cleanup(store, opts)
+    jug.subcommands.cleanup.cleanup(store, opts)
     assert store.can_load(h)
     opts.cleanup_locks_only = False
-    jug.jug.cleanup(store, opts)
+    jug.subcommands.cleanup.cleanup(store, opts)
     assert not store.can_load(h)
 

--- a/jug/tests/test_options.py
+++ b/jug/tests/test_options.py
@@ -40,7 +40,7 @@ def test_parse():
 
     assert parsed.jugfile == 'myjugfile.py'
     assert parsed.pdb
-    assert parsed.execute_wait_cycle_time_secs == 23
+    assert parsed.execute_wait_cycle_time == 23
     assert not parsed.aggressive_unload
 
 def test_copy():

--- a/jug/tests/test_status.py
+++ b/jug/tests/test_status.py
@@ -33,7 +33,7 @@ def test_cache():
     options.jugdir = store
     options.jugfile = jugfile
     options.verbose = 'quiet'
-    options.status_mode = 'cached'
+    options.status_cache = True
     options.status_cache_file = ':memory:'
 
     assert status.status(options) == 0
@@ -49,7 +49,7 @@ def test_cache_bvalue():
     options.jugdir = store
     options.jugfile = jugfile
     options.verbose = 'quiet'
-    options.status_mode = 'cached'
+    options.status_cache = True
     options.status_cache_file = ':memory:'
 
     assert status.status(options) == 0

--- a/jug/tests/test_subcommand_api.py
+++ b/jug/tests/test_subcommand_api.py
@@ -4,14 +4,25 @@ import os
 import tempfile
 import shutil
 from jug.subcommands import subcommand
+from jug.options import parse
 
 CMD = "hello-cmd"
 MSG = "Hello world"
+MSG_OPTIONS = "Hello world - option ated"
 
 
 def hello_command(*args, **kwargs):
     "This should be visible"
     return MSG
+
+
+def hello_command_opts(options, *args, **kwargs):
+    "This should be visible"
+    return MSG + " - " + options.hello_value
+
+
+def hello_options(parser):
+    parser.add_argument("--value", dest="hello_value", action="store", default="option ated")
 
 
 def clear_cmds():
@@ -45,13 +56,23 @@ subcommand.register("hello-cmd", hello_command)
     with open(os.path.join(tmpdir, userfile), 'w') as fh:
         fh.write(payload)
 
-    subcommand._load_user_commands(user_path=tmpdir)
+    subcommand._commands._load_user_commands(user_path=tmpdir)
     assert CMD in subcommand._commands, "Expected: '%s' to be in '%s'" % (CMD, subcommand._commands)
 
     output = subcommand.run(CMD)
     assert output == "This TEST"
 
     shutil.rmtree(tmpdir)
+
+
+def test_options():
+    clear_cmds()
+
+    subcommand.register(CMD, hello_command_opts, hello_options)
+    options = parse([CMD])
+    output = subcommand.run(CMD, options=options)
+
+    assert output == MSG_OPTIONS, "Expected: '%s' , got: '%s'" % (MSG_OPTIONS, output)
 
 
 def test_usage():

--- a/jug/tests/test_subcommand_api.py
+++ b/jug/tests/test_subcommand_api.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 import shutil
+from six import StringIO
 from jug.subcommands import subcommand
 from jug.options import parse
 
@@ -23,6 +24,7 @@ def hello_command_opts(options, *args, **kwargs):
 
 def hello_options(parser):
     parser.add_argument("--value", dest="hello_value", action="store", default="option ated")
+    parser.add_argument("--other-value", dest="hello_other_value", action="store", default="undefined")
 
 
 def clear_cmds():
@@ -73,6 +75,22 @@ def test_options():
     output = subcommand.run(CMD, options=options)
 
     assert output == MSG_OPTIONS, "Expected: '%s' , got: '%s'" % (MSG_OPTIONS, output)
+
+
+_options_file = '''
+[hello]
+other_value='someone'
+'''
+
+
+def test_options_config():
+    clear_cmds()
+
+    subcommand.register(CMD, hello_command_opts, hello_options)
+    options = parse([CMD], StringIO(_options_file))
+
+    assert options.hello_other_value == "someone"
+    assert options.hello_value == "option ated"
 
 
 def test_usage():

--- a/jug/tests/test_subcommand_api.py
+++ b/jug/tests/test_subcommand_api.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+import shutil
+from jug.subcommands import subcommand
+
+CMD = "hello-cmd"
+MSG = "Hello world"
+
+
+def hello_command(*args, **kwargs):
+    "This should be visible"
+    return MSG
+
+
+def clear_cmds():
+    subcommand._commands.clear()
+    assert CMD not in subcommand._commands
+
+
+def test_register():
+    clear_cmds()
+
+    subcommand.register(CMD, hello_command)
+    output = subcommand.run(CMD)
+
+    assert output == MSG, "Expected: '%s' , got: '%s'" % (MSG, output)
+
+
+def test_user_commands():
+    clear_cmds()
+
+    payload = """
+from jug.subcommands import subcommand
+
+def hello_command(*args, **kwargs):
+    "This should be visible"
+    return "This TEST"
+
+subcommand.register("hello-cmd", hello_command)
+"""
+    userfile = "jug_user_commands.py"
+    tmpdir = tempfile.mkdtemp(prefix="jug")
+    with open(os.path.join(tmpdir, userfile), 'w') as fh:
+        fh.write(payload)
+
+    subcommand._load_user_commands(user_path=tmpdir)
+    assert CMD in subcommand._commands, "Expected: '%s' to be in '%s'" % (CMD, subcommand._commands)
+
+    output = subcommand.run(CMD)
+    assert output == "This TEST"
+
+    shutil.rmtree(tmpdir)
+
+
+def test_usage():
+    clear_cmds()
+
+    subcommand.register(CMD, hello_command)
+    output = subcommand.usage(_print=False, exit=False)
+
+    assert "This should be visible" in output
+
+# vim: ai sts=4 et sw=4

--- a/jug/tests/test_subcommand_api.py
+++ b/jug/tests/test_subcommand_api.py
@@ -23,8 +23,15 @@ def hello_command_opts(options, *args, **kwargs):
 
 
 def hello_options(parser):
-    parser.add_argument("--value", dest="hello_value", action="store", default="option ated")
-    parser.add_argument("--other-value", dest="hello_other_value", action="store", default="undefined")
+    parser.add_argument("--value", dest="hello_value", action="store")
+    parser.add_argument("--other-value", dest="hello_other_value", action="store")
+
+    default_values = {
+        "hello_value": "option ated",
+        "hello_other_value": "undefined",
+    }
+
+    return default_values
 
 
 def clear_cmds():
@@ -79,7 +86,7 @@ def test_options():
 
 _options_file = '''
 [hello]
-other_value='someone'
+other-value=someone
 '''
 
 


### PR DESCRIPTION
This pull request includes a large refactor and new feature plus some small bugfixes and documentation.

Some modules used may not be available in 2.6. (Is 2.6 still a target?)
Waiting for travis to report on this.

The code refactor was both to modularize commands and solidify the project structure.
Little code was modified, most was simply moved.
Most new code was added to `subcommands/__init__.py`.
All subcommands now live under `jug.subcommands`.

A user can now include custom commands by use of `~/.config/jug/jug_user_commands.py` or via `jug.subcommands.subcommand.register()`.

For more information check the documentation included with the pull request (also to check if it's clear).