### PR TITLE
Backwards compatibility fixes

### DIFF
--- a/jug/options.py
+++ b/jug/options.py
@@ -227,6 +227,19 @@ def parse(args=None, optionsfile=None):
     for sub in subparsers:
         define_options(sub)
 
+    if args is None:
+        # If reading from sys.argv, argparse discards the first argument
+        # Since we filter sys.argv manually, we do the same here
+        args = sys.argv[1:]
+
+    try:
+        end_pos = args.index('--')
+    except ValueError:
+        remaining_args = []
+    else:
+        remaining_args = args[end_pos + 1:]
+        args = args[:end_pos]
+
     argopts = parser.parse_args(args)
 
     inifile = read_configuration_file(optionsfile, default_options=default_options)
@@ -258,6 +271,10 @@ def parse(args=None, optionsfile=None):
     logging.debug("default args: %s", default_options.__dict__)
     logging.debug("default subcommand args: %s", default_options.next.__dict__)
     logging.debug("continuing with: %s", cmdline.__dict__)
+
+    # jugscripts can rely on having the jugfile as first argument and the remaining
+    # arguments after --
+    sys.argv[:] = [cmdline.jugfile] + remaining_args
 
     return cmdline
 

--- a/jug/options.py
+++ b/jug/options.py
@@ -209,8 +209,9 @@ def parse(args=None, optionsfile=None):
     import argparse
     from .subcommands import cmdapi
 
-    if len(sys.argv) == 1:
-        cmdapi.usage()
+    if args is None:
+        if len(sys.argv) <= 1:
+            cmdapi.usage()
 
     parser = argparse.ArgumentParser(
         description=cmdapi.usage(_print=False, exit=False),

--- a/jug/tests/test_subcommand_api.py
+++ b/jug/tests/test_subcommand_api.py
@@ -30,11 +30,10 @@ class HelloCommand(SubCommand):
         }
 
 
-def clear_cmds():
-    # Remove all registered commands
-    cmdapi._commands.clear()
-
-    assert CMD not in cmdapi._commands
+class HelloNoSelfRegister(HelloCommand):
+    "No self register"
+    def __init__(self):
+        pass
 
 
 def clear_default(default):
@@ -44,29 +43,27 @@ def clear_default(default):
         pass
 
 
-class HelloNoSelfRegister(HelloCommand):
-    "No self register"
-    def __init__(self):
-        pass
+class TestSubCommandAPI():
+    def setup(self):
+        self._old_commands = cmdapi._commands.copy()
+        cmdapi._commands.clear()
 
+    def teardown(self):
+        cmdapi._commands.clear()
+        cmdapi._commands.update(self._old_commands)
 
-def test_register():
-    clear_cmds()
+    def test_register(self):
+        hello_command = HelloNoSelfRegister()
+        assert "hello-cmd" not in cmdapi._commands
 
-    hello_command = HelloNoSelfRegister()
-    assert "hello-cmd" not in cmdapi._commands
+        cmdapi._register(CMD, hello_command)
+        assert "hello-cmd" in cmdapi._commands
 
-    cmdapi._register(CMD, hello_command)
-    assert "hello-cmd" in cmdapi._commands
+        output = cmdapi.run(CMD)
+        assert output == MSG, "Expected: '%s' , got: '%s'" % (MSG, output)
 
-    output = cmdapi.run(CMD)
-    assert output == MSG, "Expected: '%s' , got: '%s'" % (MSG, output)
-
-
-def test_user_commands():
-    clear_cmds()
-
-    payload = """
+    def test_user_commands(self):
+        payload = """
 from jug.subcommands import SubCommand
 
 class HelloCommandPayload(SubCommand):
@@ -79,68 +76,60 @@ class HelloCommandPayload(SubCommand):
 
 hello_command = HelloCommandPayload()
 """
-    userfile = "jug_user_commands.py"
-    tmpdir = tempfile.mkdtemp(prefix="jug")
-    with open(os.path.join(tmpdir, userfile), 'w') as fh:
-        fh.write(payload)
+        userfile = "jug_user_commands.py"
+        tmpdir = tempfile.mkdtemp(prefix="jug")
+        with open(os.path.join(tmpdir, userfile), 'w') as fh:
+            fh.write(payload)
 
-    cmdapi._commands._load_user_commands(user_path=tmpdir)
-    CMD = "hello-payload"
-    assert CMD in cmdapi._commands, "Expected: '%s' to be in '%s'" % (CMD, cmdapi._commands)
+        cmdapi._commands._load_user_commands(user_path=tmpdir)
+        CMD = "hello-payload"
+        assert CMD in cmdapi._commands, "Expected: '%s' to be in '%s'" % (CMD, cmdapi._commands)
 
-    output = cmdapi.run(CMD)
-    assert output == "This TEST"
+        output = cmdapi.run(CMD)
+        assert output == "This TEST"
 
-    shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir)
 
+    def test_usage(self):
+        HelloCommand()
+        output = cmdapi.usage(_print=False, exit=False)
 
-def test_usage():
-    clear_cmds()
+        assert "This should be visible" in output
 
-    HelloCommand()
-    output = cmdapi.usage(_print=False, exit=False)
+    def test_options_cmdline(self):
+        clear_default("hello_other_value")
+        clear_default("hello_value")
 
-    assert "This should be visible" in output
+        assert CMD not in cmdapi._commands
 
+        HelloCommand()
 
-def test_options_cmdline():
-    clear_cmds()
+        options = parse([CMD, "--value", "FooBar"])
+        assert options.hello_value == "FooBar"
+        assert options.hello_other_value == "undefined"
 
-    clear_default("hello_other_value")
-    clear_default("hello_value")
+        output = cmdapi.run(CMD, options=options)
+        assert output == "Hello world", "Got '{0}'".format(output)
 
-    assert CMD not in cmdapi._commands
+    def test_options_config(self):
+        "Test if settings read from config file work even for custom subcommands"
 
-    HelloCommand()
-
-    options = parse([CMD, "--value", "FooBar"])
-    assert options.hello_value == "FooBar"
-    assert options.hello_other_value == "undefined"
-
-    output = cmdapi.run(CMD, options=options)
-    assert output == "Hello world", "Got '{0}'".format(output)
-
-
-def test_options_config():
-    "Test if settings read from config file work even for custom subcommands"
-    clear_cmds()
-
-    _options_file = '''
+        _options_file = '''
 [hello]
 other-value=someone
 '''
 
-    clear_default("hello_other_value")
-    clear_default("hello_value")
+        clear_default("hello_other_value")
+        clear_default("hello_value")
 
-    cmd = HelloCommand()
-    defaults = cmd.parse_defaults()
-    assert defaults["hello_other_value"] == "undefined"
-    assert defaults["hello_value"] == "option"
+        cmd = HelloCommand()
+        defaults = cmd.parse_defaults()
+        assert defaults["hello_other_value"] == "undefined"
+        assert defaults["hello_value"] == "option"
 
-    options = parse([CMD], StringIO(_options_file))
+        options = parse([CMD], StringIO(_options_file))
 
-    assert options.hello_other_value == "someone"
-    assert options.hello_value == "option"
+        assert options.hello_other_value == "someone"
+        assert options.hello_value == "option"
 
 # vim: ai sts=4 et sw=4

--- a/jug/tests/test_sys_argv.py
+++ b/jug/tests/test_sys_argv.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import tempfile
+from .task_reset import task_reset
+from jug.jug import init
+from jug.options import parse
+from jug.subcommands.execute import execute
+import json
+from six import StringIO
+
+
+class catch_stdout:
+    def __enter__(self):
+        sys.stdout = StringIO()
+        return sys.stdout
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        sys.stdout.seek(0)
+        sys.stdout = sys.__stdout__
+
+
+@task_reset
+def test_sys_argv():
+    payload = """
+import json, sys
+sys.stdout.write(json.dumps(sys.argv) + '\\n')
+"""
+    jugfile = tempfile.NamedTemporaryFile(suffix=".py")
+    jugfile.write(payload.encode("utf8"))
+    jugfile.flush()
+
+    options = parse(["execute", jugfile.name, '--', '--noarg', 'here'])
+    assert sys.argv[0] == jugfile.name
+
+    store, space = init(jugfile.name, 'dict_store')
+
+    with catch_stdout() as stdout:
+        execute.run(options=options, store=store, jugspace=space)
+
+    output = stdout.readline()
+    args = json.loads(output)
+    expected = [jugfile.name, "--noarg", "here"]
+    assert args == expected, "Saw {}, expected {}".format(args, expected)


### PR DESCRIPTION
`sys.argv` now contains jugfile and unparsed arguments (i.e. after `--`)
The subcommand api tests were also leaking causing other parts of the testsuite to fail.