### PR TITLE
MIN Don't require a trailing slash on jugdir redis addresses

### DIFF
--- a/jug/backends/redis_store.py
+++ b/jug/backends/redis_store.py
@@ -52,7 +52,7 @@ def _lockname(name):
 
 _LOCKED = 1
 
-_redis_urlpat = re.compile(r'redis://(?P<host>[A-Za-z0-9\.\-]+)(\:(?P<port>[0-9]+))?/')
+_redis_urlpat = re.compile(r'redis://(?P<host>[A-Za-z0-9\.\-]+)(\:(?P<port>[0-9]+))?/?')
 
 
 class redis_store(base_store):


### PR DESCRIPTION
All these are now valid:
redis://example.com
redis://example.com:1234
redis://example.com:1234/

Before only the last was valid.