### PR TITLE
Added missing colon in Redis listlocks()

### DIFF
--- a/jug/backends/redis_store.py
+++ b/jug/backends/redis_store.py
@@ -143,7 +143,7 @@ class redis_store(base_store):
     def listlocks(self):
         locks = self.redis.keys('lock:*')
         for lk in locks:
-            yield lk[len('lock:')]
+            yield lk[len('lock:'):]
 
 
     def getlock(self, name):


### PR DESCRIPTION
Hi, I found this little issue affecting the jug status command. It was causing nothing to come back as "running". I am not sure if there might have been other issues as a result of this.