### PR TITLE
BUG Non-zero exit with 'jug execute --keep-going' and failures

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+version 1.5.0+git
+	* 'jug execute --keep-going' now ends with non-zero exit code in case of failures
+
 version 1.5.0 Sun Jul 16 2017 by luispedro
 	* Add 'demo' subcommand
 	* Add is_jug_running() function

--- a/jug/jug.py
+++ b/jug/jug.py
@@ -136,6 +136,7 @@ def execution_loop(tasks, options):
         tasks = [t for t in tasks if task_matcher(t.name)]
         logging.info('Non-matching tasks discarded. Remaining (%s tasks)' % len(tasks))
 
+    failures = False
     prevtask = None
     while tasks:
         upnext = [] # tasks that can be run
@@ -248,11 +249,15 @@ def execution_loop(tasks, options):
                                 logging.critical('Other tasks are dependent on this one! Parallel processors will be held waiting!')
                 if not options.execute_keep_going:
                     raise
+                else:
+                    failures = True
             finally:
                 if locked:
                     t.unlock()
             if options.aggressive_unload and prevtask is not None:
                 prevtask.unload()
+
+    return failures
 
 
 def main(argv=None):


### PR DESCRIPTION
'jug execute --keep-going' would always exit cleanly even when some tasks failed.
This fix makes jug exit with returncode 1 if any task fails and returncode 0 if all tasks succeed.