### PR TITLE
Implement jug cleanup --keep-locks & misc bugfixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ version 1.5.0+git
 	* 'jug execute --keep-going' now ends with non-zero exit code in case of failures
 	* Add 'graph' subcommand - Generates a graph of tasks
 	* Fix bug with cleanup in dict_store not providing the number of removed records
+	* Add 'jug cleanup --keep-locks' to remove obsolete results without affecting locks
 
 version 1.5.0 Sun Jul 16 2017 by luispedro
 	* Add 'demo' subcommand

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 version 1.5.0+git
 	* 'jug execute --keep-going' now ends with non-zero exit code in case of failures
 	* Add 'graph' subcommand - Generates a graph of tasks
+	* Fix bug with cleanup in dict_store not providing the number of removed records
 
 version 1.5.0 Sun Jul 16 2017 by luispedro
 	* Add 'demo' subcommand

--- a/jug/backends/base.py
+++ b/jug/backends/base.py
@@ -27,10 +27,11 @@ backend.
 It can be used as a starting point (template) for writing new backends.
 '''
 
+from six import add_metaclass
 from abc import ABCMeta, abstractmethod
 
+@add_metaclass(ABCMeta)
 class base_store(object):
-    __metaclass__ = ABCMeta
     def __init__(self, name):
         '''
         base_store(name)
@@ -202,8 +203,8 @@ class base_store(object):
         return None
 
 
+@add_metaclass(ABCMeta)
 class base_lock(object):
-    __metaclass__ = ABCMeta
     '''
 
     Functions:

--- a/jug/backends/base.py
+++ b/jug/backends/base.py
@@ -121,9 +121,9 @@ class base_store(object):
         '''
 
     @abstractmethod
-    def cleanup(self, active):
+    def cleanup(self, active, keeplocks=False):
         '''
-        nr_removed = store.cleanup(active)
+        nr_removed = store.cleanup(active, keeplocks)
 
         Implement 'cleanup' command
 
@@ -131,6 +131,8 @@ class base_store(object):
         ----------
         active : sequence
             files *not to remove*
+        keeplocks : boolean
+            whether to preserve or remove locks
 
         Returns
         -------

--- a/jug/backends/dict_store.py
+++ b/jug/backends/dict_store.py
@@ -29,7 +29,7 @@ import six
 from six.moves import cPickle as pickle
 from collections import defaultdict
 
-from .base import base_store
+from .base import base_store, base_lock
 
 def _gen_key(key, name):
     if type(name) != six.text_type:
@@ -173,7 +173,7 @@ class dict_store(base_store):
 
 
 _NOT_LOCKED, _LOCKED = 0,1
-class dict_lock(object):
+class dict_lock(base_lock):
     '''
     dict_lock
 

--- a/jug/backends/dict_store.py
+++ b/jug/backends/dict_store.py
@@ -116,8 +116,12 @@ class dict_store(base_store):
                 existing.remove(_resultname(act))
             except KeyError:
                 pass
+
+        cleaned = len(existing)
         for superflous in existing:
             del self.store[superflous]
+
+        return cleaned
 
     def remove_locks(self):
         '''

--- a/jug/backends/dict_store.py
+++ b/jug/backends/dict_store.py
@@ -104,7 +104,7 @@ class dict_store(base_store):
             del self.store[_resultname(name)]
 
 
-    def cleanup(self, active):
+    def cleanup(self, active, keeplocks=False):
         '''
         cleanup()
 
@@ -116,6 +116,13 @@ class dict_store(base_store):
                 existing.remove(_resultname(act))
             except KeyError:
                 pass
+
+        if keeplocks:
+            for lock in self.listlocks():
+                try:
+                    existing.remove(_lockname(lock))
+                except ValueError:
+                    pass
 
         cleaned = len(existing)
         for superflous in existing:

--- a/jug/backends/file_store.py
+++ b/jug/backends/file_store.py
@@ -32,7 +32,7 @@ import errno
 import tempfile
 import shutil
 
-from .base import base_store
+from .base import base_store, base_lock
 from jug.backends.encode import encode_to, decode_from
 
 def create_directories(dname):
@@ -356,7 +356,7 @@ class file_store(base_store):
             shutil.rmtree(jugdir)
 
 
-class file_based_lock(object):
+class file_based_lock(base_lock):
     '''
     file_based_lock: File-system based locks
 

--- a/jug/backends/file_store.py
+++ b/jug/backends/file_store.py
@@ -242,9 +242,9 @@ class file_store(base_store):
         except OSError:
             return False
 
-    def cleanup(self, active):
+    def cleanup(self, active, keeplocks=False):
         '''
-        nr_removed = store.cleanup(active)
+        nr_removed = store.cleanup(active, keeplocks)
 
         Implement 'cleanup' command
 
@@ -252,6 +252,8 @@ class file_store(base_store):
         ----------
         active : sequence
             files *not to remove*
+        keeplocks : boolean
+            whether to preserve or remove locks
 
         Returns
         -------
@@ -261,6 +263,8 @@ class file_store(base_store):
         active = frozenset(self._getfname(t.hash()) for t in active)
         removed = 0
         for dir,_,fs in os.walk(self.jugdir):
+            if keeplocks and dir == "locks":
+                continue
             for f in fs:
                 f = path.join(dir, f)
                 if f not in active:

--- a/jug/backends/memoize_store.py
+++ b/jug/backends/memoize_store.py
@@ -100,7 +100,7 @@ class memoize_store(base_store):
         '''
         raise NotImplementedError
 
-    def cleanup(self, active):
+    def cleanup(self, active, keeplocks=False):
         '''
         cleanup()
 

--- a/jug/backends/memoize_store.py
+++ b/jug/backends/memoize_store.py
@@ -24,8 +24,10 @@
 memoize_store: a wrapper that never repeats a lookup.
 '''
 
+from .base import base_store, base_lock
 
-class memoize_store(object):
+
+class memoize_store(base_store):
     def __init__(self, base, list_base=False):
         '''
         '''
@@ -56,6 +58,16 @@ class memoize_store(object):
         return self.cache['can-load',name]
 
 
+    def list(self):
+        '''
+        for key in store.list():
+            ...
+
+        Iterates over all the keys in the store
+        '''
+        raise NotImplementedError
+
+
     def load(self, name):
         '''
         obj = load(name)
@@ -75,6 +87,18 @@ class memoize_store(object):
         '''
         raise NotImplementedError
 
+    def remove_locks(self):
+        '''
+        removed = store.remove_locks()
+
+        Remove all locks
+
+        Returns
+        -------
+        removed : int
+            Number of locks removed
+        '''
+        raise NotImplementedError
 
     def cleanup(self, active):
         '''
@@ -94,7 +118,7 @@ class memoize_store(object):
 
 
 _UNKNOWN, _NOT_LOCKED, _LOCKED = -1,False,True
-class cache_lock(object):
+class cache_lock(base_lock):
     '''
     cache_lock
 

--- a/jug/backends/redis_store.py
+++ b/jug/backends/redis_store.py
@@ -114,7 +114,7 @@ class redis_store(base_store):
         return self.redis.delete(_resultname(name))
 
 
-    def cleanup(self, active):
+    def cleanup(self, active, keeplocks=False):
         '''
         cleanup()
 
@@ -126,6 +126,13 @@ class redis_store(base_store):
                 existing.remove(_resultname(act.hash()))
             except ValueError:
                 pass
+
+        if keeplocks:
+            for lock in self.listlocks():
+                try:
+                    existing.remove(_lockname(lock))
+                except ValueError:
+                    pass
 
         cleaned = len(existing)
         for superflous in existing:

--- a/jug/subcommands/__init__.py
+++ b/jug/subcommands/__init__.py
@@ -116,6 +116,7 @@ import sys
 import traceback
 from ..options import Options
 from abc import ABCMeta, abstractmethod, abstractproperty
+from six import add_metaclass
 
 
 class SubCommandError(Exception):
@@ -146,10 +147,10 @@ Original error was:
 """ % (module, e))
 
 
+@add_metaclass(ABCMeta)
 class SubCommand:
     """Define a subcommand and its command-line options
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self):
         cmdapi._register(self.name, self)

--- a/jug/subcommands/cleanup.py
+++ b/jug/subcommands/cleanup.py
@@ -44,16 +44,22 @@ class CleanupCommand(SubCommand):
             removed = store.remove_locks()
         else:
             tasks = task.alltasks
-            removed = store.cleanup(tasks)
+            removed = store.cleanup(tasks, keeplocks=options.cleanup_keep_locks)
+
         options.print_out('Removed %s files' % removed)
 
     def parse(self, parser):
-        parser.add_argument('--locks-only',
-                            action='store_const', const=True,
-                            dest='cleanup_locks_only')
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument('--locks-only',
+                           action='store_const', const=True,
+                           dest='cleanup_locks_only')
+        group.add_argument('--keep-locks',
+                           action='store_const', const=True,
+                           dest='cleanup_keep_locks')
 
     def parse_defaults(self):
         return {
+            "cleanup_keep_locks": False,
             "cleanup_locks_only": False,
         }
 


### PR DESCRIPTION
Implementation for #54 

A note of caution as this breaks backwards compatibility by introducing an extra argument to `store.cleanup`.

**Note**: This history stacks with #56 to avoid conflicts with the Changelog file.
#56 should be merged first.