### PR TITLE
Update Travis link

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -159,7 +159,7 @@ What do I need to run Jug?
 ---------------------------
 
 It is a Python only package. Jug is `continuously tested
-<https://travis-ci.org/luispedro/jug>`__ with Python 2.6 and up (including
+<https://travis-ci.com/luispedro/jug>`__ with Python 2.6 and up (including
 Python 3.3 and up).
 
 How does it work?


### PR DESCRIPTION
CI is hosted on travis-ci.com now: https://travis-ci.com/github/luispedro/jug