### PR TITLE
add options to webstatus subcommand (port, ipaddress) 

### DIFF
--- a/jug/subcommands/webstatus.py
+++ b/jug/subcommands/webstatus.py
@@ -140,13 +140,13 @@ class WebStatusCommand(SubCommand):
                             action='store', 
                             dest='webstatus_port',
                             help=('Port for the webstatus serve to listen on'
-                                  '(Default: 8080')
+                                  ' (Default: 8080)')
         )
         parser.add_argument('--ip',
                             action='store',
                             dest='webstatus_ip',
                             help=('The IP address the webstatus server will listen on.'
-                                  '(Default: localhost')
+                                  ' (Default: localhost)')
         )
 
     def parse_defaults(self):

--- a/jug/subcommands/webstatus.py
+++ b/jug/subcommands/webstatus.py
@@ -122,17 +122,38 @@ class WebStatusCommand(SubCommand):
             return
 
         app = bottle.Bottle()
-
         @app.route('/')
         def status():
             ht, deps, rdeps = st.retrieve_sqlite3(connection)
-            tw, tre, tru, tf, dirty = st.update_status(store, ht, deps, rdeps)
+            tw, tre, tru, tfailed, tf, dirty = st.update_status(store, ht, deps, rdeps)
             st.save_dirty3(connection, dirty)
             return template % {
                 'jugfile': options.jugfile,
                 'table': _format_counts(tw, tre, tru, tf),
             }
-        bottle.run(app)
+        bottle.run(app, port=options.webstatus_port,
+                   host=options.webstatus_ip)
+
+    def parse(self, parser):
+        defaults = self.parse_defaults()
+        parser.add_argument('--port',
+                            action='store', 
+                            dest='webstatus_port',
+                            help=('Port for the webstatus serve to listen on'
+                                  '(Default: 8080')
+        )
+        parser.add_argument('--ip',
+                            action='store',
+                            dest='webstatus_ip',
+                            help=('The IP address the webstatus server will listen on.'
+                                  '(Default: localhost')
+        )
+
+    def parse_defaults(self):
+        return {
+            "webstatus_port": '8080',
+            "webstatus_ip": 'localhost'
+        }
 
 
 webstatus = WebStatusCommand()

--- a/jug/subcommands/webstatus.py
+++ b/jug/subcommands/webstatus.py
@@ -28,7 +28,9 @@ from . import SubCommand
 template = '''
 <html>
 <head>
-
+<head>
+  <meta http-equiv="refresh" content="%(refresh)s">
+</head>
 <title>Jug Status :: %(jugfile)s</title>
 <style>
 body {
@@ -107,6 +109,7 @@ class WebStatusCommand(SubCommand):
 
         try:
             import bottle
+            from bottle import request
         except ImportError:
             from sys import stderr
             stderr.write('''
@@ -129,10 +132,11 @@ class WebStatusCommand(SubCommand):
             st.save_dirty3(connection, dirty)
             return template % {
                 'jugfile': options.jugfile,
+                'refresh': request.query.refresh or "3",
                 'table': _format_counts(tw, tre, tru, tf),
             }
         bottle.run(app, port=options.webstatus_port,
-                   host=options.webstatus_ip)
+                   host=options.webstatus_ip, quiet=True)
 
     def parse(self, parser):
         defaults = self.parse_defaults()


### PR DESCRIPTION
See issue #82 

I've added two optional arguments, so the help message is:

```sh
webstatus:
  --port WEBSTATUS_PORT
                        Port for the webstatus serve to listen on (Default: 8080)
  --ip WEBSTATUS_IP     The IP address the webstatus server will listen on. (Default: localhost)
```

Also minor fix to retrieve correct values from st.update_status.

