### PR TITLE
Fix bool conversion in config

### DIFF
--- a/jug/options.py
+++ b/jug/options.py
@@ -149,7 +149,10 @@ def read_configuration_file(fp=None, default_options=None):
                 old_value = getattr(default_options, new_name, None)
                 if old_value is not None:
                     # Cast the config object to the same type as the default
-                    value = type(old_value)(value)
+                    if isinstance(old_value, bool):
+                        value = _str_to_bool(value)
+                    else:
+                        value = type(old_value)(value)
 
             logging.debug("Setting %s to %s", new_name, value)
             setattr(inifile, new_name, value)

--- a/jug/tests/test_options.py
+++ b/jug/tests/test_options.py
@@ -83,3 +83,17 @@ def test_bool():
     assert _str_to_bool("on")
     assert _str_to_bool("true")
     assert _str_to_bool("1")
+
+
+_bool_options_file = """
+[main]
+will-cite=false
+"""
+
+
+def test_bool_from_config():
+    opts = jug.options.read_configuration_file(
+        StringIO(_bool_options_file),
+        default_options=jug.options.default_options,
+    )
+    assert opts.will_cite is False


### PR DESCRIPTION
## Summary
- fix `read_configuration_file` to handle booleans correctly
- add test verifying boolean options read from config files

## Testing
- `pytest jug/tests/test_options.py::test_bool_from_config -q`
- `pytest -q` *(fails: PermissionError not raised in test_file_store)*

------
https://chatgpt.com/codex/tasks/task_e_68706f74a7708333a636882e32c08f08