### PR TITLE
Annotate Task.load() error with task name and hash

### DIFF
--- a/jug/task.py
+++ b/jug/task.py
@@ -172,7 +172,14 @@ tricky to support since the general code relies on the function name)''')
         Nothing
         '''
         assert self.can_load()
-        self._result = self.store.load(self.hash())
+        try:
+            self._result = self.store.load(self.hash())
+        except Exception as e:
+            h = self.hash().decode()
+            raise RuntimeError(
+                "Failed to load result for task '{}' (hash: {}, at '{}/{}'): {}".format(
+                    self.name, h, h[:2], h[2:], e)
+            ) from e
 
     def invalidate(self):
         '''


### PR DESCRIPTION
I had an issue with one of my pipelines where task outputs became corrupted somehow. The error message didn't specify the task hash, making it difficult to find and surgically recompute the relevant tasks.

The "fix" was just to add a try/catch around the load and add an error message to specifically print the offending task hash and file path for manual removal.