### PR TITLE
BUG Fall back to pickle for object-dtype numpy arrays

### DIFF
--- a/jug/backends/encode.py
+++ b/jug/backends/encode.py
@@ -68,7 +68,7 @@ def encode_to(object, stream):
     write = lambda obj,s: pickle.dump(obj, s, protocol=pickle.HIGHEST_PROTOCOL)
     try:
         import numpy as np
-        if type(object) is np.ndarray:
+        if type(object) is np.ndarray and object.dtype.kind != 'O':
             prefix = b'N'
             # We need to switch the arguments around because pickle.dump and
             # np.save have different argument orders:

--- a/jug/backends/file_store.py
+++ b/jug/backends/file_store.py
@@ -67,7 +67,7 @@ def fsync_dir(fname):
 def _write_to(value, output, compress_numpy):
     try:
         import numpy as np
-        if not compress_numpy and type(value) is np.ndarray:
+        if not compress_numpy and type(value) is np.ndarray and value.dtype != object:
             np.lib.format.write_array(output, value)
             return
     except ImportError:


### PR DESCRIPTION
I think Jug's file store has mismatched write and read paths for `numpy` object arrays. The write uses `np.lib.format.write_array` and then the read tries to use `np.lib.format.read_array` which, since numpy 1.16.3, has had `allow_pickle=False`.

# Reproduction

```python
import jug
import numpy as np

@jug.TaskGenerator
def make_feature_names():
    return np.array(['foo', 'bar', 'baz'], dtype=object)

@jug.TaskGenerator
def use_names(names):
    return len(names)

names = make_feature_names()
result = use_names(names)
```

```
$ jug execute --aggressive-unload mwe_bug.py
[...]
CRITICAL Exception while running mwe_bug.use_names:
  Error -3 while decompressing data: incorrect header check
```

You have to pass `--aggressive-unload` to force Jug to evict each completed task's result from
memory so downstream tasks must reload from disk. (The same failure occurs
without the flag whenever two workers run concurrently, because worker B never
holds worker A's in-memory result.)

# Fix

Change the writer: detect `dtype=object` at write time and route
through `encode_to` (the zlib+pickle path) so the existing `decode_from`
fallback works correctly.

```python
if not compress_numpy and type(value) is np.ndarray and object.dtype.kind != 'O':
    np.lib.format.write_array(output, value)
    return
```

I am open to other fixes also this just seemed the most obvious (if a touch inelegant).

Let me know what you think--happy to do something different if you think it would be better.